### PR TITLE
Add unit tests and round watch utility

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,3 +19,5 @@ IncludeCategories:
     Priority: 2
   - Regex: '"'
     Priority: 4
+#
+SortIncludes: CaseSensitive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(PROJECT_VERSION_DESCRIPTION "Test and probes")
 ### Options
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 option(BUILD_DOC "Build documentation" OFF)
-option(BUILD_TEST "Build test-applications" OFF)
+option(BUILD_TEST "Build test-applications" ON)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros.
 include(GNUInstallDirs)
@@ -82,6 +82,9 @@ configure_file("${CMAKE_SOURCE_DIR}/.cmake/version.hpp.in" "${CMAKE_BINARY_DIR}/
 #set(SPDLOG_FMT_EXTERNAL TRUE)
 
 add_subdirectory(subModules)
+
+### library C++ support library
+add_subdirectory(lib)
 
 ### application.
 add_subdirectory(src)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(src)

--- a/lib/include/cppsl/buffer/circularBuffer.hpp
+++ b/lib/include/cppsl/buffer/circularBuffer.hpp
@@ -1,10 +1,10 @@
-/* SPDX-License-Identifier: MIT */
+// SPDX-License-Identifier: MIT
 
-/*************************************************************************/ /**
- * \file
- * @brief  contains cyclic buffer template lock free thread-safe.
+/**
+ * @file
+ * @brief Contains a lock-free, thread-safe circular buffer template.
  * @ingroup C++ support library
- *****************************************************************************/
+ */
 
 #pragma once
 
@@ -14,15 +14,14 @@
 
 namespace cppsl::buffer {
 
-template <typename T>
 /**
+ * @class CircularBuffer
  * @brief A thread-safe circular buffer implementation.
  * @tparam T The type of items stored in the buffer.
- * @param size The size of the circular buffer. Must be a power of 2.
- * @throws std::invalid_argument if the size is not a power of 2.
  */
+template <typename T>
 class CircularBuffer {
-  const size_t m_capacity;           ///< The size of the circular buffer.
+  const size_t m_capacity{16};       ///< The size of the circular buffer.
   std::vector<T> m_buffer;           ///< The buffer storing the items.
   std::atomic<size_t> m_readIndex;   ///< The read index for the circular buffer.
   std::atomic<size_t> m_writeIndex;  ///< The write index for the circular buffer.
@@ -32,10 +31,9 @@ class CircularBuffer {
    * @brief Constructor: Ensures the size is a power of 2 and initializes the buffer and indices.
    * @param size The size of the circular buffer. Must be a power of 2.
    * @throws std::invalid_argument if the size is not a power of 2.
-   * @return An instance of CircularBuffer.
    */
   explicit CircularBuffer(size_t size = 16)
-      : m_capacity(nextPowerOf2(size)), m_buffer(m_capacity), m_readIndex(0), m_writeIndex(0) {
+      : m_capacity(nextPowerOf2(size)), m_buffer(nextPowerOf2(size)), m_readIndex(0), m_writeIndex(0) {
     if ((m_capacity & (m_capacity - 1)) != 0) {
       throw std::invalid_argument("Size must be a power of 2");
     }
@@ -47,7 +45,6 @@ class CircularBuffer {
    * The method uses relaxed memory ordering for reading and releasing memory, and
    * acquire memory ordering for acquiring memory.
    *
-   * @tparam T The type of items stored in the buffer.
    * @param item The item to be added to the circular buffer.
    * @return true if the item was successfully added to the buffer, false if the buffer is full.
    */
@@ -71,7 +68,6 @@ class CircularBuffer {
    * The pop method removes the next item from the circular buffer if it is not empty.
    * The method uses relaxed memory ordering for reading and acquiring memory ordering for releasing memory.
    *
-   * @tparam T The type of items stored in the buffer.
    * @param item A reference to the variable where the popped item will be stored.
    * @return true if an item was successfully popped from the buffer, false if the buffer is empty.
    */
@@ -120,7 +116,6 @@ class CircularBuffer {
    * current read index. It uses the readIndex_ and writeIndex_ atomic variables to perform the comparison.
    * The method uses the acquire memory ordering for reading the index values.
    *
-   * @tparam T The type of items stored in the buffer.
    * @return true if the circular buffer is full, false otherwise.
    */
   [[nodiscard]] bool full() const {
@@ -187,7 +182,7 @@ class CircularBuffer {
    * @param index The index to be incremented.
    * @return The incremented index within the circular buffer.
    */
-  size_t increment(size_t index) const {
+  [[nodiscard]] size_t increment(size_t index) const {
     return (index + 1) & (m_capacity - 1);
   }
 };

--- a/lib/include/cppsl/buffer/circularBuffer.hpp
+++ b/lib/include/cppsl/buffer/circularBuffer.hpp
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * \file
+ * @brief  contains cyclic buffer template lock free thread-safe.
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <stdexcept>
+#include <vector>
+
+namespace cppsl::buffer {
+
+template <typename T>
+/**
+ * @brief A thread-safe circular buffer implementation.
+ * @tparam T The type of items stored in the buffer.
+ * @param size The size of the circular buffer. Must be a power of 2.
+ * @throws std::invalid_argument if the size is not a power of 2.
+ */
+class CircularBuffer {
+  const size_t m_capacity;           ///< The size of the circular buffer.
+  std::vector<T> m_buffer;           ///< The buffer storing the items.
+  std::atomic<size_t> m_readIndex;   ///< The read index for the circular buffer.
+  std::atomic<size_t> m_writeIndex;  ///< The write index for the circular buffer.
+
+ public:
+  /**
+   * @brief Constructor: Ensures the size is a power of 2 and initializes the buffer and indices.
+   * @param size The size of the circular buffer. Must be a power of 2.
+   * @throws std::invalid_argument if the size is not a power of 2.
+   * @return An instance of CircularBuffer.
+   */
+  explicit CircularBuffer(size_t size = 16)
+      : m_capacity(nextPowerOf2(size)), m_buffer(m_capacity), m_readIndex(0), m_writeIndex(0) {
+    if ((m_capacity & (m_capacity - 1)) != 0) {
+      throw std::invalid_argument("Size must be a power of 2");
+    }
+  }
+
+  /**
+   * @brief Adds an item to the buffer.
+   * The push method adds the specified item to the circular buffer if it is not full.
+   * The method uses relaxed memory ordering for reading and releasing memory, and
+   * acquire memory ordering for acquiring memory.
+   *
+   * @tparam T The type of items stored in the buffer.
+   * @param item The item to be added to the circular buffer.
+   * @return true if the item was successfully added to the buffer, false if the buffer is full.
+   */
+  [[nodiscard]] bool push(const T& item) {
+    auto currentWrite = m_writeIndex.load(std::memory_order_relaxed);
+    auto nextWrite = increment(currentWrite);
+
+    if (nextWrite == m_readIndex.load(std::memory_order_acquire)) {
+      // Buffer is full
+      return false;
+    }
+
+    m_buffer[currentWrite] = item;
+    m_writeIndex.store(nextWrite, std::memory_order_release);
+
+    return true;
+  }
+
+  /**
+   * @brief Removes the next item from the circular buffer.
+   * The pop method removes the next item from the circular buffer if it is not empty.
+   * The method uses relaxed memory ordering for reading and acquiring memory ordering for releasing memory.
+   *
+   * @tparam T The type of items stored in the buffer.
+   * @param item A reference to the variable where the popped item will be stored.
+   * @return true if an item was successfully popped from the buffer, false if the buffer is empty.
+   */
+  [[nodiscard]] bool pop(T& item) {
+    auto currentRead = m_readIndex.load(std::memory_order_relaxed);
+
+    if (currentRead == m_writeIndex.load(std::memory_order_acquire)) {
+      // Buffer is empty
+      return false;
+    }
+
+    item = m_buffer[currentRead];
+    m_readIndex.store(increment(currentRead), std::memory_order_release);
+
+    return true;
+  }
+
+  /**
+   * @brief Clears the circular buffer by resetting the read and write indices to 0.
+   *
+   * The clear method resets the read and write indices of the circular buffer to 0,
+   * effectively removing all items from the buffer. It uses the std::memory_order_release memory ordering
+   * when storing the new index values.
+   */
+  void clear() {
+    m_readIndex.store(0, std::memory_order_release);
+    m_writeIndex.store(0, std::memory_order_release);
+  }
+
+  /**
+   * @brief Checks if the circular buffer is empty.
+   * The empty method returns true if the circular buffer is empty, i.e., if the read index is equal to the write index.
+   * It uses the readIndex_ and writeIndex_ atomic variables to perform the comparison.
+   * The method uses the acquire memory ordering for reading the index values.
+   *
+   * @return true if the circular buffer is empty, false otherwise.
+   */
+  [[nodiscard]] bool empty() const {
+    return m_readIndex.load(std::memory_order_acquire) == m_writeIndex.load(std::memory_order_acquire);
+  }
+
+  /**
+   * @brief Checks if the circular buffer is full.
+   *
+   * The full method returns true if the circular buffer is full, i.e., if the next write index is equal to the
+   * current read index. It uses the readIndex_ and writeIndex_ atomic variables to perform the comparison.
+   * The method uses the acquire memory ordering for reading the index values.
+   *
+   * @tparam T The type of items stored in the buffer.
+   * @return true if the circular buffer is full, false otherwise.
+   */
+  [[nodiscard]] bool full() const {
+    return increment(m_writeIndex.load(std::memory_order_acquire)) == m_readIndex.load(std::memory_order_acquire);
+  }
+
+  /**
+   * @brief Returns the capacity of the circular buffer.
+   *
+   * The capacity method returns the size of the circular buffer, which is the maximum number of items
+   * that can be stored in the buffer.
+   *
+   * @return The capacity of the circular buffer.
+   */
+  [[nodiscard]] size_t capacity() const {
+    return m_capacity;
+  }
+
+  /**
+   * @brief Returns the number of items currently in the circular buffer.
+   *
+   * The size method calculates and returns the number of items currently in the circular buffer.
+   * It uses the read and write indices to perform the calculation.
+   * The method uses the acquire memory ordering for reading the index values.
+   *
+   * @return The number of items currently in the circular buffer.
+   */
+  [[nodiscard]] size_t size() const {
+    auto currentWrite = m_writeIndex.load(std::memory_order_acquire);
+    auto currentRead = m_readIndex.load(std::memory_order_acquire);
+    return (currentWrite - currentRead + m_capacity) & (m_capacity - 1);
+  }
+
+ private:
+  /**
+   * @brief Determines the next power of 2 for a given number.
+   * @param num The number to find the next power of 2 for.
+   * @return The next power of 2 for the given number.
+   */
+  size_t nextPowerOf2(size_t num) {
+    if (num == 0) {
+      return 1;
+    } else if ((num & (num - 1)) == 0) {
+      return num;
+    } else {
+      --num;
+      num |= num >> 1;
+      num |= num >> 2;
+      num |= num >> 4;
+      num |= num >> 8;
+      num |= num >> 16;
+#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__)
+      num |= num >> 32;
+#endif
+      return num + 1;
+    }
+  }
+
+  /**
+   * @brief Increments the given index by 1 and applies bitwise AND operation with size_ - 1.
+   * The increment method increments the given index by 1 and applies a bitwise AND operation with size_ - 1
+   * to ensure that the index stays within the circular buffer's bounds.
+   *
+   * @param index The index to be incremented.
+   * @return The incremented index within the circular buffer.
+   */
+  size_t increment(size_t index) const {
+    return (index + 1) & (m_capacity - 1);
+  }
+};
+
+}  // namespace cppsl::buffer

--- a/lib/include/cppsl/container/dequeSafe.hpp
+++ b/lib/include/cppsl/container/dequeSafe.hpp
@@ -129,13 +129,18 @@ class DequeSafe {
    *
    * @param value A reference to store the popped element.
    */
-  [[maybe_unused]] void wait_and_pop_front(TypeElement& value) {
+  [[maybe_unused]] bool wait_and_pop_front(TypeElement& value,
+                                           std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
     std::unique_lock<std::mutex> lk(m_semaphore);
-    m_condition.wait(lk, [this] {
+    m_condition.wait_for(lk, timeout, [this] {
       return !m_container.empty();
     });
+    if (m_container.empty()) {
+      return false;
+    }
     value = m_container.front();
     m_container.pop_front();
+    return true;
   }
 
   /**
@@ -147,13 +152,18 @@ class DequeSafe {
    *
    * @param value A reference to store the popped element.
    */
-  [[maybe_unused]] void wait_and_pop_back(TypeElement& value) {
+  [[maybe_unused]] bool wait_and_pop_back(TypeElement& value,
+                                          std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
     std::unique_lock<std::mutex> lk(m_semaphore);
-    m_condition.wait(lk, [this] {
+    m_condition.wait_for(lk, timeout, [this] {
       return !m_container.empty();
     });
+    if (m_container.empty()) {
+      return false;
+    }
     value = m_container.back();
     m_container.pop_back();
+    return true;
   }
 
   /**
@@ -165,9 +175,10 @@ class DequeSafe {
    *
    * @return A shared pointer to the first element of the deque.
    */
-  [[maybe_unused]] std::shared_ptr<TypeElement> wait_and_pop_front() {
+  [[maybe_unused]] std::shared_ptr<TypeElement> wait_and_pop_front(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
     std::unique_lock<std::mutex> lk(m_semaphore);
-    m_condition.wait(lk, [this] {
+    m_condition.wait_for(lk, timeout, [this] {
       return !m_container.empty();
     });
     std::shared_ptr<TypeElement> res(std::make_shared<TypeElement>(m_container.front()));
@@ -184,9 +195,10 @@ class DequeSafe {
    *
    * @return A shared pointer to the last element of the deque.
    */
-  [[maybe_unused]] std::shared_ptr<TypeElement> wait_and_pop_back() {
+  [[maybe_unused]] std::shared_ptr<TypeElement> wait_and_pop_back(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
     std::unique_lock<std::mutex> lk(m_semaphore);
-    m_condition.wait(lk, [this] {
+    m_condition.wait_for(lk, timeout, [this] {
       return !m_container.empty();
     });
     std::shared_ptr<TypeElement> res(std::make_shared<TypeElement>(m_container.back()));

--- a/lib/include/cppsl/container/dequeSafe.hpp
+++ b/lib/include/cppsl/container/dequeSafe.hpp
@@ -1,34 +1,17 @@
-/* SPDX-License-Identifier: MIT */
+// SPDX-License-Identifier: MIT
 
-/*************************************************************************/ /**
+/**
  * @file
- * @brief   contains a safe dual queue container using fixed size memory
- * allocation and handling of elements at both ends in constant time..
+ * @brief Contains a safe dual queue container using fixed size memory allocation and handling of elements at both ends in constant time.
  * @ingroup Container
- *****************************************************************************/
+ */
 
 #pragma once
-
-//-----------------------------------------------------------------------------
-// includes
-//-----------------------------------------------------------------------------
 
 #include <condition_variable>
 #include <deque>
 #include <memory>
 #include <mutex>
-
-//----------------------------------------------------------------------------
-// Defines and macros
-//----------------------------------------------------------------------------
-
-//----------------------------------------------------------------------------
-// Typedefs, structs, enums, unions and variables
-//----------------------------------------------------------------------------
-
-//----------------------------------------------------------------------------
-// Public Prototypes
-//----------------------------------------------------------------------------
 
 namespace cppsl::container {
 
@@ -42,48 +25,38 @@ namespace cppsl::container {
  * synchronized access to the underlying deque.
  *
  * @tparam TypeElement The type of elements stored in the deque.
- * @tparam _TAlloc The allocator type for element construction, defaults to std::allocator<T>.
+ * @tparam TAlloc The allocator type for element construction, defaults to std::allocator<TypeElement>.
  */
-template <typename TypeElement, typename _TAlloc = std::allocator<TypeElement>>
+template <typename TypeElement, typename TAlloc = std::allocator<TypeElement>>
 class DequeSafe {
   mutable std::mutex m_semaphore;       ///< Mutex to protect the deque container
   std::condition_variable m_condition;  ///< Condition variable to notify waiting threads
   std::deque<TypeElement> m_container;  ///< The underlying deque container
 
  public:
-  /// default constructor
-  DequeSafe() {}
+  /// Default constructor
+  DequeSafe() = default;
 
-  /**
-   * @class DequeSafe
-   * @brief A thread-safe implementation of deque container.
-   *
-   * The DequeSafe class implements a thread-safe version of the deque container,
-   * which allows multiple threads to concurrently perform operations on the container
-   * without causing any data race. It uses a mutex and condition variable to ensure
-   * synchronized access to the underlying deque.
-   *
-   * @tparam T The type of elements stored in the deque.
-   * @tparam _TAlloc The allocator type for element construction, defaults to std::allocator<T>.
-   */
-  DequeSafe(DequeSafe const& other) {
+  /// Copy constructor
+  DequeSafe(const DequeSafe& other) {
     std::lock_guard<std::mutex> lk(other.m_semaphore);
     m_container = other.m_container;
   }
 
   /**
-    * @brief Removes all elements from the container.
-    *
-    * The clear function acquires a lock on the semaphore and removes all elements from the container.
-    * After clearing the container, it is empty.
-    */
+   * @brief Removes all elements from the container.
+   *
+   * The clear function acquires a lock on the semaphore and removes all elements from the container.
+   * After clearing the container, it is empty.
+   */
   void clear() {
     std::lock_guard<std::mutex> lk(m_semaphore);
     m_container.clear();
   }
 
   /**
-   *
+   * @brief Returns a reference to the first element in the deque.
+   * @return A reference to the first element in the deque.
    */
   TypeElement& front() {
     std::lock_guard<std::mutex> lk(m_semaphore);
@@ -91,9 +64,8 @@ class DequeSafe {
   }
 
   /**
-   * @brief Returns a reference to the first element in the deque.
-   * @return const TypeElement& - A reference to the first element in the deque.
-   * @see m_semaphore, m_container
+   * @brief Returns a const reference to the first element in the deque.
+   * @return A const reference to the first element in the deque.
    */
   const TypeElement& front() const {
     std::lock_guard<std::mutex> lk(m_semaphore);
@@ -101,7 +73,7 @@ class DequeSafe {
   }
 
   /**
-   * Retrieves a reference to the last element of the container.
+   * @brief Retrieves a reference to the last element of the container.
    * @return A reference to the last element in the container.
    */
   TypeElement& back() {
@@ -119,16 +91,15 @@ class DequeSafe {
   }
 
   /**
-    * @brief Adds a new element to the front of the deque container.
-    *
-    * This function acquires a lock on the semaphore and adds the new value
-    * to the front of the deque container. It then notifies one waiting thread
-    * that the deque is no longer empty.
-    *
-    * @tparam T The type of elements stored in the deque.
-    * @param new_value The value to be added to the deque.
-    */
-  void push_front(TypeElement new_value) {
+   * @brief Adds a new element to the front of the deque container.
+   *
+   * This function acquires a lock on the semaphore and adds the new value
+   * to the front of the deque container. It then notifies one waiting thread
+   * that the deque is no longer empty.
+   *
+   * @param new_value The value to be added to the deque.
+   */
+  [[maybe_unused]] void push_front(TypeElement new_value) {
     std::lock_guard<std::mutex> lk(m_semaphore);
     m_container.push_front(new_value);
     m_condition.notify_one();
@@ -141,7 +112,6 @@ class DequeSafe {
    * to the end of the deque container. It then notifies one waiting thread
    * that the deque is no longer empty.
    *
-   * @tparam T The type of elements stored in the deque.
    * @param new_value The value to be added to the deque.
    */
   void push_back(TypeElement new_value) {
@@ -157,10 +127,9 @@ class DequeSafe {
    * Once the deque is not empty, it pops the first element from the deque and assigns it
    * to the given value.
    *
-   * @tparam T The type of elements stored in the deque.
    * @param value A reference to store the popped element.
    */
-  void wait_and_pop_front(TypeElement& value) {
+  [[maybe_unused]] void wait_and_pop_front(TypeElement& value) {
     std::unique_lock<std::mutex> lk(m_semaphore);
     m_condition.wait(lk, [this] {
       return !m_container.empty();
@@ -176,10 +145,9 @@ class DequeSafe {
    * Once the deque is not empty, it pops the last element from the deque and assigns it
    * to the given value.
    *
-   * @tparam T The type of elements stored in the deque.
    * @param value A reference to store the popped element.
    */
-  void wait_and_pop_back(TypeElement& value) {
+  [[maybe_unused]] void wait_and_pop_back(TypeElement& value) {
     std::unique_lock<std::mutex> lk(m_semaphore);
     m_condition.wait(lk, [this] {
       return !m_container.empty();
@@ -195,10 +163,9 @@ class DequeSafe {
    * Once the deque is not empty, it pops the first element from the deque, creates a shared pointer
    * to that element, and returns it.
    *
-   * @tparam T The type of elements stored in the deque.
    * @return A shared pointer to the first element of the deque.
    */
-  std::shared_ptr<TypeElement> wait_and_pop_front() {
+  [[maybe_unused]] std::shared_ptr<TypeElement> wait_and_pop_front() {
     std::unique_lock<std::mutex> lk(m_semaphore);
     m_condition.wait(lk, [this] {
       return !m_container.empty();
@@ -209,16 +176,15 @@ class DequeSafe {
   }
 
   /**
-    * @brief Waits until the deque is not empty and pops the last element from the deque.
-    *
-    * This function acquires a lock on the semaphore and waits until the deque is not empty.
-    * Once the deque is not empty, it pops the last element from the deque, creates a shared pointer
-    * to that element, and returns it.
-    *
-    * @tparam T The type of elements stored in the deque.
-    * @return A shared pointer to the last element of the deque.
-    */
-  std::shared_ptr<TypeElement> wait_and_pop_back() {
+   * @brief Waits until the deque is not empty and pops the last element from the deque.
+   *
+   * This function acquires a lock on the semaphore and waits until the deque is not empty.
+   * Once the deque is not empty, it pops the last element from the deque, creates a shared pointer
+   * to that element, and returns it.
+   *
+   * @return A shared pointer to the last element of the deque.
+   */
+  [[maybe_unused]] std::shared_ptr<TypeElement> wait_and_pop_back() {
     std::unique_lock<std::mutex> lk(m_semaphore);
     m_condition.wait(lk, [this] {
       return !m_container.empty();
@@ -229,31 +195,30 @@ class DequeSafe {
   }
 
   /**
-  * @brief Attempts to pop the last element from the deque if it is not empty.
-  *
-  * This function acquires a lock on the semaphore and checks if the deque is empty.
-  * If it is not empty, it pops the last element from the deque and assigns it to the given value.
-  * If the deque is empty, it returns false.
-  *
-  * @tparam T The type of elements stored in the deque.
-  * @param value A reference to store the popped element.
-  * @return True if an element was successfully popped, false otherwise.
-  */
-  bool try_pop_back(TypeElement& value) {
+   * @brief Attempts to pop the last element from the deque if it is not empty.
+   *
+   * This function acquires a lock on the semaphore and checks if the deque is empty.
+   * If it is not empty, it pops the last element from the deque and assigns it to the given value.
+   * If the deque is empty, it returns false.
+   *
+   * @param value A reference to store the popped element.
+   * @return True if an element was successfully popped, false otherwise.
+   */
+  [[maybe_unused]] bool try_pop_back(TypeElement& value) {
     std::lock_guard<std::mutex> lk(m_semaphore);
     if (m_container.empty()) {
       return false;
     }
     value = m_container.back();
     m_container.pop_back();
-    return (true);
+    return true;
   }
 
   /**
    * @brief Tries to pop the last element from the deque if it is not empty.
    * @return A shared pointer to the popped element, or nullptr if the deque is empty.
    */
-  std::shared_ptr<TypeElement> try_pop_back() {
+  [[maybe_unused]] std::shared_ptr<TypeElement> try_pop_back() {
     std::lock_guard<std::mutex> lk(m_semaphore);
     if (m_container.empty()) {
       return std::shared_ptr<TypeElement>();
@@ -268,7 +233,7 @@ class DequeSafe {
    * @param value The variable to store the popped element.
    * @return True if an element was successfully popped, false otherwise.
    */
-  bool try_pop_front(TypeElement& value) {
+  [[maybe_unused]] bool try_pop_front(TypeElement& value) {
     std::lock_guard<std::mutex> lk(m_semaphore);
     if (m_container.empty()) {
       return false;
@@ -282,7 +247,7 @@ class DequeSafe {
    * @brief Tries to pop the first element from the deque if it is not empty.
    * @return A shared pointer to the popped element, or nullptr if the deque is empty.
    */
-  std::shared_ptr<TypeElement> try_pop_front() {
+  [[maybe_unused]] std::shared_ptr<TypeElement> try_pop_front() {
     std::lock_guard<std::mutex> lk(m_semaphore);
     if (m_container.empty()) {
       return std::shared_ptr<TypeElement>();
@@ -293,7 +258,7 @@ class DequeSafe {
   }
 
   /**
-   * @brief Check if the container is empty.
+   * @brief Checks if the container is empty.
    *
    * The empty function acquires a lock on the semaphore and checks if the container is empty.
    *

--- a/lib/include/cppsl/container/dequeSafe.hpp
+++ b/lib/include/cppsl/container/dequeSafe.hpp
@@ -1,0 +1,320 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * @file
+ * @brief   contains a safe dual queue container using fixed size memory
+ * allocation and handling of elements at both ends in constant time..
+ * @ingroup Container
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+
+//----------------------------------------------------------------------------
+// Defines and macros
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Typedefs, structs, enums, unions and variables
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public Prototypes
+//----------------------------------------------------------------------------
+
+namespace cppsl::container {
+
+/**
+ * @class DequeSafe
+ * @brief A thread-safe implementation of deque container.
+ *
+ * The DequeSafe class implements a thread-safe version of the deque container,
+ * which allows multiple threads to concurrently perform operations on the container
+ * without causing any data race. It uses a mutex and condition variable to ensure
+ * synchronized access to the underlying deque.
+ *
+ * @tparam TypeElement The type of elements stored in the deque.
+ * @tparam _TAlloc The allocator type for element construction, defaults to std::allocator<T>.
+ */
+template <typename TypeElement, typename _TAlloc = std::allocator<TypeElement>>
+class DequeSafe {
+  mutable std::mutex m_semaphore;       ///< Mutex to protect the deque container
+  std::condition_variable m_condition;  ///< Condition variable to notify waiting threads
+  std::deque<TypeElement> m_container;  ///< The underlying deque container
+
+ public:
+  /// default constructor
+  DequeSafe() {}
+
+  /**
+   * @class DequeSafe
+   * @brief A thread-safe implementation of deque container.
+   *
+   * The DequeSafe class implements a thread-safe version of the deque container,
+   * which allows multiple threads to concurrently perform operations on the container
+   * without causing any data race. It uses a mutex and condition variable to ensure
+   * synchronized access to the underlying deque.
+   *
+   * @tparam T The type of elements stored in the deque.
+   * @tparam _TAlloc The allocator type for element construction, defaults to std::allocator<T>.
+   */
+  DequeSafe(DequeSafe const& other) {
+    std::lock_guard<std::mutex> lk(other.m_semaphore);
+    m_container = other.m_container;
+  }
+
+  /**
+    * @brief Removes all elements from the container.
+    *
+    * The clear function acquires a lock on the semaphore and removes all elements from the container.
+    * After clearing the container, it is empty.
+    */
+  void clear() {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    m_container.clear();
+  }
+
+  /**
+   *
+   */
+  TypeElement& front() {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    return m_container.front();
+  }
+
+  /**
+   * @brief Returns a reference to the first element in the deque.
+   * @return const TypeElement& - A reference to the first element in the deque.
+   * @see m_semaphore, m_container
+   */
+  const TypeElement& front() const {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    return m_container.front();
+  }
+
+  /**
+   * Retrieves a reference to the last element of the container.
+   * @return A reference to the last element in the container.
+   */
+  TypeElement& back() {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    return m_container.back();
+  }
+
+  /**
+   * @brief Returns a const reference to the last element in the deque.
+   * @return A const reference to the last element in the deque.
+   */
+  const TypeElement& back() const {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    return m_container.back();
+  }
+
+  /**
+    * @brief Adds a new element to the front of the deque container.
+    *
+    * This function acquires a lock on the semaphore and adds the new value
+    * to the front of the deque container. It then notifies one waiting thread
+    * that the deque is no longer empty.
+    *
+    * @tparam T The type of elements stored in the deque.
+    * @param new_value The value to be added to the deque.
+    */
+  void push_front(TypeElement new_value) {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    m_container.push_front(new_value);
+    m_condition.notify_one();
+  }
+
+  /**
+   * @brief Adds a new element to the end of the deque container.
+   *
+   * This function acquires a lock on the semaphore and adds the new value
+   * to the end of the deque container. It then notifies one waiting thread
+   * that the deque is no longer empty.
+   *
+   * @tparam T The type of elements stored in the deque.
+   * @param new_value The value to be added to the deque.
+   */
+  void push_back(TypeElement new_value) {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    m_container.push_back(new_value);
+    m_condition.notify_one();
+  }
+
+  /**
+   * @brief Waits until the deque is not empty and pops the first element from the deque.
+   *
+   * This function acquires a lock on the semaphore and waits until the deque is not empty.
+   * Once the deque is not empty, it pops the first element from the deque and assigns it
+   * to the given value.
+   *
+   * @tparam T The type of elements stored in the deque.
+   * @param value A reference to store the popped element.
+   */
+  void wait_and_pop_front(TypeElement& value) {
+    std::unique_lock<std::mutex> lk(m_semaphore);
+    m_condition.wait(lk, [this] {
+      return !m_container.empty();
+    });
+    value = m_container.front();
+    m_container.pop_front();
+  }
+
+  /**
+   * @brief Waits until the deque is not empty and pops the last element.
+   *
+   * This function acquires a lock on the semaphore and waits until the deque is not empty.
+   * Once the deque is not empty, it pops the last element from the deque and assigns it
+   * to the given value.
+   *
+   * @tparam T The type of elements stored in the deque.
+   * @param value A reference to store the popped element.
+   */
+  void wait_and_pop_back(TypeElement& value) {
+    std::unique_lock<std::mutex> lk(m_semaphore);
+    m_condition.wait(lk, [this] {
+      return !m_container.empty();
+    });
+    value = m_container.back();
+    m_container.pop_back();
+  }
+
+  /**
+   * @brief Waits until the deque is not empty and pops the first element from the deque.
+   *
+   * This function acquires a lock on the semaphore and waits until the deque is not empty.
+   * Once the deque is not empty, it pops the first element from the deque, creates a shared pointer
+   * to that element, and returns it.
+   *
+   * @tparam T The type of elements stored in the deque.
+   * @return A shared pointer to the first element of the deque.
+   */
+  std::shared_ptr<TypeElement> wait_and_pop_front() {
+    std::unique_lock<std::mutex> lk(m_semaphore);
+    m_condition.wait(lk, [this] {
+      return !m_container.empty();
+    });
+    std::shared_ptr<TypeElement> res(std::make_shared<TypeElement>(m_container.front()));
+    m_container.pop_front();
+    return res;
+  }
+
+  /**
+    * @brief Waits until the deque is not empty and pops the last element from the deque.
+    *
+    * This function acquires a lock on the semaphore and waits until the deque is not empty.
+    * Once the deque is not empty, it pops the last element from the deque, creates a shared pointer
+    * to that element, and returns it.
+    *
+    * @tparam T The type of elements stored in the deque.
+    * @return A shared pointer to the last element of the deque.
+    */
+  std::shared_ptr<TypeElement> wait_and_pop_back() {
+    std::unique_lock<std::mutex> lk(m_semaphore);
+    m_condition.wait(lk, [this] {
+      return !m_container.empty();
+    });
+    std::shared_ptr<TypeElement> res(std::make_shared<TypeElement>(m_container.back()));
+    m_container.pop_back();
+    return res;
+  }
+
+  /**
+  * @brief Attempts to pop the last element from the deque if it is not empty.
+  *
+  * This function acquires a lock on the semaphore and checks if the deque is empty.
+  * If it is not empty, it pops the last element from the deque and assigns it to the given value.
+  * If the deque is empty, it returns false.
+  *
+  * @tparam T The type of elements stored in the deque.
+  * @param value A reference to store the popped element.
+  * @return True if an element was successfully popped, false otherwise.
+  */
+  bool try_pop_back(TypeElement& value) {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    if (m_container.empty()) {
+      return false;
+    }
+    value = m_container.back();
+    m_container.pop_back();
+    return (true);
+  }
+
+  /**
+   * @brief Tries to pop the last element from the deque if it is not empty.
+   * @return A shared pointer to the popped element, or nullptr if the deque is empty.
+   */
+  std::shared_ptr<TypeElement> try_pop_back() {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    if (m_container.empty()) {
+      return std::shared_ptr<TypeElement>();
+    }
+    std::shared_ptr<TypeElement> res(std::make_shared<TypeElement>(m_container.back()));
+    m_container.pop_back();
+    return res;
+  }
+
+  /**
+   * @brief Tries to pop the first element from the deque if it is not empty.
+   * @param value The variable to store the popped element.
+   * @return True if an element was successfully popped, false otherwise.
+   */
+  bool try_pop_front(TypeElement& value) {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    if (m_container.empty()) {
+      return false;
+    }
+    value = m_container.front();
+    m_container.pop_front();
+    return true;
+  }
+
+  /**
+   * @brief Tries to pop the first element from the deque if it is not empty.
+   * @return A shared pointer to the popped element, or nullptr if the deque is empty.
+   */
+  std::shared_ptr<TypeElement> try_pop_front() {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    if (m_container.empty()) {
+      return std::shared_ptr<TypeElement>();
+    }
+    std::shared_ptr<TypeElement> res(std::make_shared<TypeElement>(m_container.front()));
+    m_container.pop_front();
+    return res;
+  }
+
+  /**
+   * @brief Check if the container is empty.
+   *
+   * The empty function acquires a lock on the semaphore and checks if the container is empty.
+   *
+   * @return True if the container is empty, False otherwise.
+   */
+  bool empty() const {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    return m_container.empty();
+  }
+
+  /**
+   * @brief Returns the size of the container.
+   *
+   * The size function acquires a lock on the semaphore and returns the current size of the container.
+   *
+   * @return The size of the container.
+   */
+  size_t size() const {
+    std::lock_guard<std::mutex> lk(m_semaphore);
+    return m_container.size();
+  }
+};
+
+}  // namespace cppsl::container

--- a/lib/include/cppsl/container/queueLockFree.hpp
+++ b/lib/include/cppsl/container/queueLockFree.hpp
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * @file
+ * @brief   contains lock free queue shared pointers.
+ * @author  Alexander Sacharov <alexcvc@gmail.com>
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// Includes
+//-----------------------------------------------------------------------------
+#include <atomic>
+#include <memory>
+
+//----------------------------------------------------------------------------
+// Defines and macros
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Typedefs, structs, enums, unions and variables
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public Prototypes
+//----------------------------------------------------------------------------
+
+namespace cppsl::container {
+
+/**
+ * @class queueLockFree
+ * @brief A lock-free queue data structure implementation.
+ *
+ * This class provides a lock-free queue data structure, where multiple threads can
+ * simultaneously push and pop elements without encountering any races or deadlocks.
+ *
+ * @tparam T The type of the elements stored in the queue.
+ */
+template <typename T>
+class queueLockFree {
+  /**
+     * @brief A node used in the queueLockFree class.
+     * This class represents a node in the lock-free queue data structure.
+     * It contains a shared pointer to the data and a pointer to the next node.
+     */
+  struct node {
+    std::shared_ptr<T> m_dataSp;
+    node* m_next{nullptr};
+  };
+
+  /// atomic head and tail of queue
+  std::atomic<node*> m_head;
+  std::atomic<node*> m_tail;
+
+ public:
+  /**
+     * @brief A lock-free queue data structure implementation.
+     * @tparam T The type of the elements stored in the queue.
+     */
+  queueLockFree() : m_head(new node), m_tail(m_head.load()) {}
+
+  /**
+     * @brief A lock-free queue data structure implementation.
+     * @tparam T The type of the elements stored in the queue.
+     */
+  ~queueLockFree() {
+    while (node* const old_head = m_head.load()) {
+      m_head.store(old_head->m_next);
+      delete old_head;
+    }
+  }
+  queueLockFree(const queueLockFree& other) = delete;
+  queueLockFree& operator=(const queueLockFree& other) = delete;
+
+  /**
+   * @brief Checks if the queue is empty.
+   * @return bool True if the queue is empty, false otherwise.
+   */
+  [[nodiscard]] bool empty() {
+    node* const old_head = m_head.load();
+    if (old_head == m_tail.load()) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @brief Returns a pointer to the first node at the head of the lock-free queue.
+   * @return const node* A pointer to the first node at the head of the queue if successful,
+   * or nullptr if the queue is empty.
+   */
+  [[nodiscard]] const node* front() const {
+    node* const head = m_head.load();
+    if (head == m_tail.load()) {
+      return nullptr;
+    }
+    return head;
+  }
+
+  /**
+   * @brief Returns a pointer to the last element in the lock-free queue.
+   * @return const node* A pointer to the last element in the queue if successful,
+   * or nullptr if the queue is empty.
+   */
+  [[nodiscard]] const node* back() const {
+    node* const tail = m_tail.load();
+    if (tail == m_head.load()) {
+      return nullptr;
+    }
+    return tail;
+  }
+
+  /**
+    * @brief Try to pop an element from the front of the lock-free queue.
+    *
+    * This function tries to pop an element from the front of the lock-free queue.
+    * If the queue is empty, it returns an empty shared pointer.
+    *
+    * @tparam T The type of the elements stored in the queue.
+    *
+    * @return std::shared_ptr<T> A shared pointer to the popped element if successful,
+    * or an empty shared pointer if the queue is empty.
+    */
+  [[nodiscard]] std::shared_ptr<T> try_pop() {
+    std::unique_ptr<node> old_head(pop_head());
+    return old_head ? old_head->m_dataSp : std::shared_ptr<T>();
+  }
+
+  /**
+   * @brief Pop an element from the front of the lock-free queue.
+   * @tparam T The type of the elements stored in the queue.
+   * @return std::shared_ptr<T> A shared pointer to the popped element.
+   */
+  [[nodiscard]] std::shared_ptr<T> pop() {
+    node* old_head = pop_head();
+    if (!old_head) {
+      return std::shared_ptr<T>();
+    }
+    std::shared_ptr<T> const res(old_head->m_dataSp);
+    delete old_head;
+    return res;
+  }
+
+  /**
+   * @brief Pushes a new value into the lock-free queue.
+   *
+   * This function pushes a new value into the lock-free queue. It creates a new node with
+   * the given value, and updates the tail of the queue to point to this new node.
+   *
+   * @tparam T The type of the value to be pushed into the queue.
+   * @param new_value The new value to be pushed into the queue.
+   */
+  void push(T new_value) {
+    std::shared_ptr<T> new_data(std::make_shared<T>(new_value));
+    node* p = new node;
+    node* const old_tail = m_tail.load();
+    old_tail->m_dataSp.swap(new_data);
+    old_tail->m_next = p;
+    m_tail.store(p);
+  }
+
+ private:
+  /**
+     * @brief Removes and returns the first node from the head of the lock-free queue.
+     * @return A pointer to the first node on success, or nullptr if the queue is empty.
+     */
+  node* pop_head() {
+    node* const old_head = m_head.load();
+    if (old_head == m_tail.load()) {
+      return nullptr;
+    }
+    m_head.store(old_head->m_next);
+    return old_head;
+  }
+};
+
+}  //namespace cppsl::container

--- a/lib/include/cppsl/log/details/fallback_sink.hpp
+++ b/lib/include/cppsl/log/details/fallback_sink.hpp
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: MIT */
+//
+// Copyright (c) 2015 David Schury, Gabi Melman
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+//
+
+/*************************************************************************/ /**
+ * @file
+ * @brief       contains a simple custom sink made for spdlog that will
+ * allow you to create a list of sinks and fallback on each tier if the previous
+ * sink fails.
+ *
+ * auto fallback = std::make_shared<spdlog::sinks::fallback_sink>();
+ *
+ * fallback->add_sink(std::make_shared<spdlog::sinks::sqlite_sink>("database.db"));
+ * fallback->add_sink(std::make_shared<spdlog::sinks::simple_file_sink_st>("LogFileName.log"));
+ * fallback->add_sink(std::make_shared<spdlog::sinks::stdout_sink_st>());
+ * fallback->add_sink(std::make_shared<spdlog::sinks::null_sink_st>());
+ *
+ * auto logging = std::make_shared<spdlog::logger>("fallback_logger", fallback)
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes <...>
+//-----------------------------------------------------------------------------
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+// clang-format off
+#include <spdlog/details/log_msg.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/sinks/sink.h>
+// clang-format on
+
+//----------------------------------------------------------------------------
+// Public defines and macros
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public typedefs, structs, enums, unions and variables
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public Function Prototypes
+//----------------------------------------------------------------------------
+
+namespace spdlog::sinks {
+class fallback_sink : public sink {
+ public:
+  ~fallback_sink() {
+    _sinks_to_remove.clear();
+    _sinks.clear();
+  }
+
+  void log(const details::log_msg& msg) override {
+    for (auto& sink : _sinks) {
+      try {
+        sink->log(msg);
+        break;
+      } catch (const std::exception& ex) {
+        sink->flush();
+
+        _sinks_to_remove.push_back(sink);
+      }
+    }
+
+    if (!_sinks_to_remove.empty()) {
+      for (auto sink_to_remove : _sinks_to_remove) {
+        remove_sink(sink_to_remove);
+      }
+      _sinks_to_remove.clear();
+    }
+  }
+
+  void flush() override {
+    for (auto& sink : _sinks)
+      sink->flush();
+  }
+
+  void add_sink(std::shared_ptr<sink> sink) {
+    _sinks.push_back(sink);
+  }
+
+  void remove_sink(std::shared_ptr<sink> sink) {
+    auto pos = std::find(_sinks.begin(), _sinks.end(), sink);
+
+    _sinks.erase(pos);
+  }
+
+ private:
+  std::vector<std::shared_ptr<sink>> _sinks;
+  std::vector<std::shared_ptr<sink>> _sinks_to_remove;
+};
+}  // namespace spdlog::sinks

--- a/lib/include/cppsl/log/details/rsyslog_sink.hpp
+++ b/lib/include/cppsl/log/details/rsyslog_sink.hpp
@@ -1,0 +1,201 @@
+/*************************************************************************/ /**
+ * @file
+ * @brief   contains implementing winconfig logging to remote server
+ * @details This implementation contains winconfig logging to remote server.
+ * For more information see:
+ * https://github.com/gabime/spdlog/wiki/4.-Sinks#implementing-your-own-sink
+ * and
+ * Documentation for WinConfig
+ *
+ * @author      Alexander Sacharov <a.sacharov@gmx.de>
+ * @date        2021-07-28
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+// clang format off
+#include <syslog.h>
+#include <unistd.h>
+
+#include <array>
+#include <map>
+#include <sstream>
+#include <string>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include "spdlog/common.h"
+#include "spdlog/details/null_mutex.h"
+#include "spdlog/details/synchronous_factory.h"
+#include "spdlog/sinks/base_sink.h"
+// clang format on
+
+//----------------------------------------------------------------------------
+// Public defines and macros
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public typedefs, structs, enums, unions and variables
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public Function Prototypes
+//----------------------------------------------------------------------------
+
+namespace spdlog {
+namespace sinks {
+  /**
+  * Sink that write to rsyslog using udp.
+  */
+  template <typename Mutex>
+  class rsyslog_sink final : public base_sink<Mutex> {
+    std::map<int, int> m_mapSeveritySpd2Syslog = {
+        {SPDLOG_LEVEL_CRITICAL, LOG_CRIT},
+        {SPDLOG_LEVEL_ERROR, LOG_ERR},
+        {SPDLOG_LEVEL_WARN, LOG_WARNING},
+        {SPDLOG_LEVEL_INFO, LOG_INFO},
+        {SPDLOG_LEVEL_DEBUG, LOG_DEBUG},
+        {SPDLOG_LEVEL_TRACE, LOG_DEBUG},
+        {SPDLOG_LEVEL_OFF, 0},
+    };
+
+    const int m_log_buffer_max_size{16777216};  ///< 16K
+    struct sockaddr_in m_sockaddr;              ///< address
+    int m_fd{-1};                               ///< socket descriptor
+    int m_facility{0};                          ///< facility
+    std::string m_ident;                        ///< identity
+    std::string m_buffer;                       ///< buffer
+
+   public:
+    /**
+    * constructor
+    * @param ident - The string pointed to by ident is prepended to every message.
+    * @param server_ip - remote syslog server IP
+    * @param facility - facility codes specifies what type of program is logging the message.
+    * This lets the configuration file specify that messages from different facilities will be handled differently.
+    * https://man7.org/linux/man-pages/man3/syslog.3.html
+    * @param port - remote port is 514 by default
+    * @param log_buffer_max_size - buffer reserved in the message string. This increases performance when creating
+     * log messages.
+    * @param enable_formatting - default false. However the message format maybe changed.
+    */
+    rsyslog_sink(const std::string& ident, const std::string& server_ip, int facility, int log_buffer_max_size,
+                 uint16_t port, bool enable_formatting)
+        : m_log_buffer_max_size(log_buffer_max_size),
+          m_facility(facility),
+          m_ident(ident),
+          m_enable_formatting(enable_formatting) {
+      if (m_log_buffer_max_size > std::numeric_limits<int>::max()) {
+        SPDLOG_THROW(spdlog_ex("too large maxLogSize"));
+      }
+
+      m_buffer.reserve(m_log_buffer_max_size);
+      // socket
+      memset(&m_sockaddr, 0, sizeof(m_sockaddr));
+      m_sockaddr.sin_family = AF_INET;
+      m_sockaddr.sin_port = htons(port);
+      inet_pton(AF_INET, server_ip.c_str(), &m_sockaddr.sin_addr);
+
+      // open  socket
+      open_socket();
+    }
+
+    /**
+    * destructor
+    */
+    ~rsyslog_sink() override {
+      close(m_fd);
+    }
+
+    /**
+    * delete copy constructor and assignment
+    */
+    rsyslog_sink(const rsyslog_sink&) = delete;
+    rsyslog_sink& operator=(const rsyslog_sink&) = delete;
+
+   protected:
+    /**
+    * sink message after severity filter
+    * @param msg - message
+    */
+    void sink_it_(const details::log_msg& msg) override {
+      if (msg.level != level::off) {
+        string_view_t payload;
+        memory_buf_t formatted;
+        if (m_enable_formatting) {
+          base_sink<Mutex>::formatter_->format(msg, formatted);
+          payload = string_view_t(formatted.data(), formatted.size());
+        } else {
+          payload = msg.payload;
+        }
+        size_t length = payload.size();
+        // limit to max int
+        length = length > static_cast<size_t>(std::numeric_limits<int>::max())
+                     ? static_cast<size_t>(std::numeric_limits<int>::max())
+                     : length;
+        std::stringstream ss;
+        // <%u>%s:
+        ss << "<" << m_facility + m_mapSeveritySpd2Syslog[msg.level] << ">" << m_ident << ": ";
+
+        m_buffer += ss.str();
+        length = length > m_log_buffer_max_size - m_buffer.size() ? m_log_buffer_max_size - m_buffer.size() : length;
+        if (length > 0) {
+          m_buffer.append(payload.data(), length);
+        }
+        if (write(m_fd, m_buffer.c_str(), m_buffer.size()) == -1)
+          perror("write error");
+        m_buffer.clear();
+      }
+    }
+
+    void flush_() override {}
+
+    bool m_enable_formatting{false};
+
+   private:
+    /**
+     * open UDP socket
+     */
+    void open_socket() {
+      int nb = 1;
+
+      if ((m_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+        SPDLOG_THROW(spdlog_ex("failed create socket"));
+      } else if (ioctl(m_fd, FIONBIO, &nb) == -1) {
+        SPDLOG_THROW(spdlog_ex("failed ioctl socket FIONBIO"));
+      } else if (connect(m_fd, reinterpret_cast<struct sockaddr*>(&m_sockaddr), sizeof(m_sockaddr)) < 0) {
+        SPDLOG_THROW(spdlog_ex("failed connect socket"));
+      }
+    }
+  };
+
+  using rsyslog_sink_mt = rsyslog_sink<std::mutex>;
+  using rsyslog_sink_st = rsyslog_sink<details::null_mutex>;
+}  // namespace sinks
+
+// Create and register a syslog logger
+template <typename Factory = synchronous_factory>
+inline std::shared_ptr<logger> rsyslog_logger_mt(const std::string& logger_name, const std::string& ident,
+                                                 const std::string& rsyslog_ip, uint facility,
+                                                 int log_buffer_max_size = 1024 * 1024 * 16, uint16_t port = 514,
+                                                 bool enable_formatting = true) {
+  return Factory::template create<sinks::rsyslog_sink_mt>(logger_name, ident, rsyslog_ip, facility, log_buffer_max_size,
+                                                          port, enable_formatting);
+}
+
+template <typename Factory = synchronous_factory>
+inline std::shared_ptr<logger> rsyslog_logger_st(const std::string& logger_name, const std::string& ident,
+                                                 const std::string& rsyslog_ip, uint facility,
+                                                 int log_buffer_max_size = 1024 * 1024 * 16, uint16_t port = 514,
+                                                 bool enable_formatting = true) {
+  return Factory::template create<sinks::rsyslog_sink_st>(logger_name, ident, rsyslog_ip, facility, log_buffer_max_size,
+                                                          port, enable_formatting);
+}
+
+}  // namespace spdlog

--- a/lib/include/cppsl/log/logManager.hpp
+++ b/lib/include/cppsl/log/logManager.hpp
@@ -1,0 +1,559 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * @file
+ * @brief  C++ wrapper class with  multiple loggers all sharing the same sink
+ * aka categories
+ * @details This class maintains spdlog details as a private inside a class.
+ * Other objects can not access to details directly, instead, they can only
+ * invoke a list of public functions. This abstracts the spdlog in logger
+ * container. One of the advantages is being able to apply the useful functions
+ * with no modification.
+ * All headers with skins are hidden in the cpp file. This brings significant
+ * benefit in compiling and breaking the dependency of all files on spdlog.
+ * We can use a logger targets with no confusion with mixing types and extra headers.
+ * Each of sinks would have their own output target in any case. This manager contain:
+ *  - one sink to console target;
+ *  - one sink to file target;
+ *  - one sink to daily file target;
+ *  - one sink to rotate file target;
+ *  - one sink to syslog target;
+ *  - one sink to remote syslog target;
+ *
+ * @author  Alexander Sacharov <alexcvc@gmail.com>
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+// clang-format off
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/logger.h>
+#include <spdlog/fmt/fmt.h>
+#include <fmt/core.h>
+
+#include "spdlog/sinks/basic_file_sink.h"
+// clang-format on
+
+/**
+ * @brief This namespace contains manager logger with skins.
+ * C++ wrapper class with  multiple loggers all sharing the same sink aka categories
+ */
+namespace cppsl::log {
+
+using log_level = spdlog::level::level_enum;
+class LogManager;
+using LogManagerPtr = std::shared_ptr<LogManager>;
+
+template <typename Factory = LogManager>
+auto CreateLoggingManager(std::string_view name) {
+  return std::make_shared<Factory>(name);
+}
+
+/**
+ * @brief Class Log implements logger in  application
+ */
+class LogManager final {
+  std::string m_name{"logman"};             ///< name of log manager
+  std::shared_ptr<spdlog::logger> m_logSp;  ///< manager handler
+
+ public:
+  enum class Colored { color, black_white };
+  enum class OutputLog : bool { err, out };
+  enum class Truncate : bool { no, by_open };
+
+  /**
+    * default constructor
+    * @param name - logging name. It is useful, if you want to serve logger by name instead shared pointer
+    */
+  LogManager() {
+    m_logSp = std::make_shared<spdlog::logger>(m_name);
+  }
+
+  LogManager(std::string_view name) : m_name(name) {
+    m_logSp = std::make_shared<spdlog::logger>(m_name);
+  }
+
+  /**
+    * destructor
+    */
+  ~LogManager() noexcept {
+    removeSinks();
+  }
+
+  /**
+   * @brief Returns the name of the logging manager.
+   * @return const std::string& The name of the logging manager.
+   */
+  [[nodiscard]] const std::string& name() const {
+    return m_name;
+  }
+
+  /**
+   * @brief Gets the number of sinks in the LogManager.
+   * @return The number of sinks in the LogManager, or 0 if the LogManager has no log pointer.
+   */
+  [[nodiscard]] size_t number_sinks() const {
+    if (m_logSp == nullptr)
+      return 0;
+    return m_logSp->sinks().size();
+  }
+
+  /**
+   *  @brief Checks if the logging manager is empty
+   *  @return TRUE if the logging manager is empty, FALSE otherwise
+   */
+  [[nodiscard]] bool empty() const {
+    if (m_logSp == nullptr)
+      return true;
+    return m_logSp->sinks().empty();
+  }
+
+  //----------------------------------------------------------
+  // Add various sinks with different parameters and levels
+  //----------------------------------------------------------
+
+  /**
+   * add basic file sink + multi sinks.
+   * @param filename - name of logfile
+   * @param howToTruncate - if true - truncate by open
+   * @param level - log level for this sink
+   */
+  [[nodiscard]] bool add_basic_file_sink(const std::string& filename, Truncate howToTruncate, log_level level) noexcept;
+
+  /**
+    * add rotation file sink.
+    * @param filename - target log file name
+    * @param max_file_size
+    * @param max_files
+    * @param level - log level for this sink
+    */
+  [[nodiscard]] bool add_rotation_file_sink(const std::string& filename, size_t max_file_size, size_t max_files,
+                                            log_level level) noexcept;
+
+  /**
+    * Create file sink which create new file on the given time (default in midnight)
+    * @param filename - target log file name
+    * @param hour
+    * @param minute
+    * @param level - log level for this sink
+    */
+  [[nodiscard]] bool add_daily_file_sink(const std::string& filename, int hour, int minute, log_level level) noexcept;
+
+  /**
+    * Create and register no-/colored console sink
+    * @param to_stderr
+    * @param colored
+    * @param level - log level for this sink
+    */
+  [[nodiscard]] bool add_console_sink(OutputLog to_stderr, Colored colored, log_level level) noexcept;
+
+  /**
+    * Create and register a rsyslog sinks to remote server
+    * @param ident - The string pointed to by ident is prepended to every message.
+    * @param rsyslog_ip - remote syslog server IP
+    * @param syslog_facility - facility codes specifies what type of program is logging the message.
+    * @param severity - severity of message
+    * More information in https://man7.org/linux/man-pages/man3/syslog.3.html
+    * @param lev - level of message
+    * @param port - remote port of server
+    * @param enable_formatting - default true. However the message format maybe changed.
+    * @param log_buffer_max_size - buffer reserved in the message string. This increases performance when creating
+    * log messages.
+    */
+  [[nodiscard]] bool add_rsyslog_sink(const std::string& ident, const std::string& rsyslog_ip, int syslog_facility,
+                                      log_level lev, int port = 514, bool enable_formatting = true,
+                                      int log_buffer_max_size = 1024 * 1024 * 16) noexcept;
+
+  /**
+    * Create and register a syslog sinks
+    * @param syslog_ident- The string pointed to by ident is prepended to every message.
+    * @param syslog_option - options. More information in https://man7.org/linux/man-pages/man3/syslog.3.html
+    * @param syslog_facility - facility codes specifies what type of program is logging the message.
+    * @param enable_formatting - default true. However the message format maybe changed.
+    * @param level - log level for this sink
+    */
+  [[nodiscard]] bool add_syslog_sink(const std::string& syslog_ident, int syslog_option, int syslog_facility,
+                                     bool enable_formatting, log_level level) noexcept;
+
+  //----------------------------------------------------------
+  // Logger startup, shutdown and drop all sinks
+  //----------------------------------------------------------
+  /**
+   * @brief Opens the logger.
+   * @return True if the logger was successfully opened, false otherwise.
+   */
+  [[nodiscard]] bool openLogger(log_level level = spdlog::level::info);
+  void push_sink_safe(spdlog::sink_ptr sinkPtr, spdlog::level::level_enum level);
+
+  /**
+   * @brief Closes the logger.
+   */
+  void closeLogger();
+
+  /**
+   * @brief Removes all the registered sinks from the log manager.
+   */
+  void removeSinks();
+
+  /**
+    * Interval based flush. This is implemented by a single worker thread that periodically
+    * calls flush() on each logger.
+    * @param interval_seconds - interval in seconds
+    */
+  void flush_every(std::chrono::seconds& interval_seconds) noexcept {
+    spdlog::flush_every(std::chrono::seconds(interval_seconds));
+  }
+
+  /**
+   * set level only for logger (general and for next sinks default)
+   * @param level - logging level
+   */
+  void set_level(spdlog::level::level_enum level) noexcept {
+    if (m_logSp) {
+      m_logSp->set_level(level);
+    }
+  }
+
+  spdlog::level::level_enum level() const noexcept {
+    if (m_logSp) {
+      return m_logSp->level();
+    }
+    return spdlog::level::off;
+  }
+
+ private:
+  void drop_all() noexcept {
+    if (m_logSp) {
+      spdlog::drop(m_name);
+    }
+  }
+
+  [[nodiscard]] bool check_create_path(const std::string& filename);
+
+  [[nodiscard]] std::shared_ptr<spdlog::sinks::sink> create_console_sink(OutputLog to_stderr, Colored colored) noexcept;
+
+  [[nodiscard]] bool initialize_console_sink(OutputLog to_stderr, Colored colored, log_level level);
+
+ public:
+  //----------------------------------------------------------
+  // trace
+  //----------------------------------------------------------
+  template <typename... Args>
+  inline void trace(fmt::format_string<Args...> fmt, Args&&... args) {
+    if (m_logSp) {
+      m_logSp->trace(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void trace(const T& msg) {
+    if (m_logSp) {
+      m_logSp->trace(msg);
+    }
+  }
+
+  template <typename... Args>
+  inline void trace_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->trace(fmt, std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void trace_if(bool flag, const T& msg) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->trace(msg);
+      }
+    }
+  }
+
+  template <typename... Args>
+  inline void trace_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+    auto logPtr = spdlog::get(name);
+    if (logPtr) {
+      logPtr->trace(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void trace_name(const std::string& name, const T& msg) {
+    std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
+    if (logPtr) {
+      // logging to multi-sink logger
+      logPtr->trace(msg);
+    }
+  }
+
+  //----------------------------------------------------------
+  // debug
+  //----------------------------------------------------------
+  template <typename... Args>
+  inline void debug(fmt::format_string<Args...> fmt, Args&&... args) {
+    if (m_logSp) {
+      m_logSp->debug(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void debug(const T& msg) {
+    if (m_logSp) {
+      m_logSp->debug(msg);
+    }
+  }
+
+  template <typename... Args>
+  inline void debug_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->debug(fmt, std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void debug_if(bool flag, const T& msg) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->debug(msg);
+      }
+    }
+  }
+
+  template <typename... Args>
+  inline void debug_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+    auto logPtr = spdlog::get(name);
+    if (logPtr) {
+      logPtr->debug(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void debug_name(const std::string& name, const T& msg) {
+    std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
+    if (logPtr) {
+      // logging to multi-sink logger
+      logPtr->debug(msg);
+    }
+  }
+
+  //----------------------------------------------------------
+  // info
+  //----------------------------------------------------------
+
+  template <typename... Args>
+  inline void info(fmt::format_string<Args...> fmt, Args&&... args) {
+    if (m_logSp) {
+      m_logSp->info(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void info(const T& msg) {
+    if (m_logSp) {
+      m_logSp->info(msg);
+    }
+  }
+
+  template <typename... Args>
+  inline void info_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->info(fmt, std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void info_if(bool flag, const T& msg) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->info(msg);
+      }
+    }
+  }
+
+  template <typename... Args>
+  inline void info_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+    auto logPtr = spdlog::get(name);
+    if (logPtr) {
+      logPtr->info(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void info_name(const std::string& name, const T& msg) {
+    std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
+    if (logPtr) {
+      // logging to multi-sink logger
+      logPtr->info(msg);
+    }
+  }
+
+  //----------------------------------------------------------
+  // warn
+  //----------------------------------------------------------
+  template <typename... Args>
+  inline void warn(fmt::format_string<Args...> fmt, Args&&... args) {
+    if (m_logSp) {
+      m_logSp->warn(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void warn(const T& msg) {
+    if (m_logSp) {
+      m_logSp->warn(msg);
+    }
+  }
+
+  template <typename... Args>
+  inline void warn_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->warn(fmt, std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void warn_if(bool flag, const T& msg) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->warn(msg);
+      }
+    }
+  }
+
+  template <typename... Args>
+  inline void warn_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+    auto logPtr = spdlog::get(name);
+    if (logPtr) {
+      logPtr->warn(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void warn_name(const std::string& name, const T& msg) {
+    std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
+    if (logPtr) {
+      // logging to multi-sink logger
+      logPtr->warn(msg);
+    }
+  }
+
+  //----------------------------------------------------------
+  // error
+  //----------------------------------------------------------
+  template <typename... Args>
+  inline void error(fmt::format_string<Args...> fmt, Args&&... args) {
+    if (m_logSp) {
+      m_logSp->error(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void error(const T& msg) {
+    if (m_logSp) {
+      m_logSp->error(msg);
+    }
+  }
+
+  template <typename... Args>
+  inline void error_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->error(fmt, std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void error_if(bool flag, const T& msg) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->error(msg);
+      }
+    }
+  }
+
+  template <typename... Args>
+  inline void error_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+    auto logPtr = spdlog::get(name);
+    if (logPtr) {
+      logPtr->error(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void error_name(const std::string& name, const T& msg) {
+    std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
+    if (logPtr) {
+      // logging to multi-sink logger
+      logPtr->error(msg);
+    }
+  }
+
+  //----------------------------------------------------------
+  // critical
+  //----------------------------------------------------------
+  template <typename... Args>
+  inline void critical(fmt::format_string<Args...> fmt, Args&&... args) {
+    if (m_logSp) {
+      m_logSp->critical(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void critical(const T& msg) {
+    if (m_logSp) {
+      m_logSp->critical(msg);
+    }
+  }
+
+  template <typename... Args>
+  inline void critical_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->critical(fmt, std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void critical_if(bool flag, const T& msg) {
+    if (flag) {
+      if (m_logSp) {
+        m_logSp->critical(msg);
+      }
+    }
+  }
+
+  template <typename... Args>
+  inline void critical_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+    auto logPtr = spdlog::get(name);
+    if (logPtr) {
+      logPtr->critical(fmt, std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  inline void critical_name(const std::string& name, const T& msg) {
+    std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
+    if (logPtr) {
+      // logging to multi-sink logger
+      logPtr->critical(msg);
+    }
+  }
+};
+
+}  // namespace cppsl::log

--- a/lib/include/cppsl/log/logManager.hpp
+++ b/lib/include/cppsl/log/logManager.hpp
@@ -73,11 +73,36 @@ class LogManager final {
     * @param name - logging name. It is useful, if you want to serve logger by name instead shared pointer
     */
   LogManager() {
+    m_name = "logman";
     m_logSp = std::make_shared<spdlog::logger>(m_name);
   }
 
   explicit LogManager(std::string_view name) : m_name(name) {
     m_logSp = std::make_shared<spdlog::logger>(m_name);
+  }
+
+  // Copy constructor
+  LogManager(const LogManager& other) : m_name(other.m_name), m_logSp(other.m_logSp) {}
+
+  // Move constructor
+  LogManager(LogManager&& other) noexcept : m_name(std::move(other.m_name)), m_logSp(std::move(other.m_logSp)) {}
+
+  // Copy assignment operator
+  LogManager& operator=(const LogManager& other) {
+    if (this != &other) {
+      m_name = other.m_name;
+      m_logSp = other.m_logSp;
+    }
+    return *this;
+  }
+
+  // Move assignment operator
+  LogManager& operator=(LogManager&& other) noexcept {
+    if (this != &other) {
+      m_name = std::move(other.m_name);
+      m_logSp = std::move(other.m_logSp);
+    }
+    return *this;
   }
 
   /**
@@ -95,6 +120,13 @@ class LogManager final {
     return m_name;
   }
 
+  const std::shared_ptr<spdlog::logger>& logPtr() const {
+    return m_logSp;
+  }
+
+  void setMLogSp(const std::shared_ptr<spdlog::logger>& mLogSp) {
+    m_logSp = mLogSp;
+  }
   /**
    * @brief Gets the number of sinks in the LogManager.
    * @return The number of sinks in the LogManager, or 0 if the LogManager has no log pointer.

--- a/lib/include/cppsl/log/logManager.hpp
+++ b/lib/include/cppsl/log/logManager.hpp
@@ -76,7 +76,7 @@ class LogManager final {
     m_logSp = std::make_shared<spdlog::logger>(m_name);
   }
 
-  LogManager(std::string_view name) : m_name(name) {
+  explicit LogManager(std::string_view name) : m_name(name) {
     m_logSp = std::make_shared<spdlog::logger>(m_name);
   }
 
@@ -207,7 +207,7 @@ class LogManager final {
     * calls flush() on each logger.
     * @param interval_seconds - interval in seconds
     */
-  void flush_every(std::chrono::seconds& interval_seconds) noexcept {
+  [[maybe_unused]] static void flush_every(std::chrono::seconds& interval_seconds) noexcept {
     spdlog::flush_every(std::chrono::seconds(interval_seconds));
   }
 
@@ -221,7 +221,7 @@ class LogManager final {
     }
   }
 
-  spdlog::level::level_enum level() const noexcept {
+  [[nodiscard]] spdlog::level::level_enum level() const noexcept {
     if (m_logSp) {
       return m_logSp->level();
     }
@@ -246,21 +246,21 @@ class LogManager final {
   // trace
   //----------------------------------------------------------
   template <typename... Args>
-  inline void trace(fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void trace(fmt::format_string<Args...> fmt, Args&&... args) {
     if (m_logSp) {
       m_logSp->trace(fmt, std::forward<Args>(args)...);
     }
   }
 
   template <typename T>
-  inline void trace(const T& msg) {
+  [[maybe_unused]] inline void trace(const T& msg) {
     if (m_logSp) {
       m_logSp->trace(msg);
     }
   }
 
   template <typename... Args>
-  inline void trace_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void trace_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
     if (flag) {
       if (m_logSp) {
         m_logSp->trace(fmt, std::forward<Args>(args)...);
@@ -269,7 +269,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void trace_if(bool flag, const T& msg) {
+  [[maybe_unused]] inline void trace_if(bool flag, const T& msg) {
     if (flag) {
       if (m_logSp) {
         m_logSp->trace(msg);
@@ -278,7 +278,7 @@ class LogManager final {
   }
 
   template <typename... Args>
-  inline void trace_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void trace_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
     auto logPtr = spdlog::get(name);
     if (logPtr) {
       logPtr->trace(fmt, std::forward<Args>(args)...);
@@ -286,7 +286,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void trace_name(const std::string& name, const T& msg) {
+  [[maybe_unused]] inline void trace_name(const std::string& name, const T& msg) {
     std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
     if (logPtr) {
       // logging to multi-sink logger
@@ -298,21 +298,21 @@ class LogManager final {
   // debug
   //----------------------------------------------------------
   template <typename... Args>
-  inline void debug(fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void debug(fmt::format_string<Args...> fmt, Args&&... args) {
     if (m_logSp) {
       m_logSp->debug(fmt, std::forward<Args>(args)...);
     }
   }
 
   template <typename T>
-  inline void debug(const T& msg) {
+  [[maybe_unused]] inline void debug(const T& msg) {
     if (m_logSp) {
       m_logSp->debug(msg);
     }
   }
 
   template <typename... Args>
-  inline void debug_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void debug_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
     if (flag) {
       if (m_logSp) {
         m_logSp->debug(fmt, std::forward<Args>(args)...);
@@ -321,7 +321,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void debug_if(bool flag, const T& msg) {
+  [[maybe_unused]] inline void debug_if(bool flag, const T& msg) {
     if (flag) {
       if (m_logSp) {
         m_logSp->debug(msg);
@@ -330,7 +330,7 @@ class LogManager final {
   }
 
   template <typename... Args>
-  inline void debug_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void debug_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
     auto logPtr = spdlog::get(name);
     if (logPtr) {
       logPtr->debug(fmt, std::forward<Args>(args)...);
@@ -338,7 +338,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void debug_name(const std::string& name, const T& msg) {
+  [[maybe_unused]] inline void debug_name(const std::string& name, const T& msg) {
     std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
     if (logPtr) {
       // logging to multi-sink logger
@@ -351,21 +351,21 @@ class LogManager final {
   //----------------------------------------------------------
 
   template <typename... Args>
-  inline void info(fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void info(fmt::format_string<Args...> fmt, Args&&... args) {
     if (m_logSp) {
       m_logSp->info(fmt, std::forward<Args>(args)...);
     }
   }
 
   template <typename T>
-  inline void info(const T& msg) {
+  [[maybe_unused]] inline void info(const T& msg) {
     if (m_logSp) {
       m_logSp->info(msg);
     }
   }
 
   template <typename... Args>
-  inline void info_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void info_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
     if (flag) {
       if (m_logSp) {
         m_logSp->info(fmt, std::forward<Args>(args)...);
@@ -374,7 +374,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void info_if(bool flag, const T& msg) {
+  [[maybe_unused]] inline void info_if(bool flag, const T& msg) {
     if (flag) {
       if (m_logSp) {
         m_logSp->info(msg);
@@ -383,7 +383,7 @@ class LogManager final {
   }
 
   template <typename... Args>
-  inline void info_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void info_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
     auto logPtr = spdlog::get(name);
     if (logPtr) {
       logPtr->info(fmt, std::forward<Args>(args)...);
@@ -391,7 +391,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void info_name(const std::string& name, const T& msg) {
+  [[maybe_unused]] inline void info_name(const std::string& name, const T& msg) {
     std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
     if (logPtr) {
       // logging to multi-sink logger
@@ -403,21 +403,21 @@ class LogManager final {
   // warn
   //----------------------------------------------------------
   template <typename... Args>
-  inline void warn(fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void warn(fmt::format_string<Args...> fmt, Args&&... args) {
     if (m_logSp) {
       m_logSp->warn(fmt, std::forward<Args>(args)...);
     }
   }
 
   template <typename T>
-  inline void warn(const T& msg) {
+  [[maybe_unused]] inline void warn(const T& msg) {
     if (m_logSp) {
       m_logSp->warn(msg);
     }
   }
 
   template <typename... Args>
-  inline void warn_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void warn_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
     if (flag) {
       if (m_logSp) {
         m_logSp->warn(fmt, std::forward<Args>(args)...);
@@ -426,7 +426,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void warn_if(bool flag, const T& msg) {
+  [[maybe_unused]] inline void warn_if(bool flag, const T& msg) {
     if (flag) {
       if (m_logSp) {
         m_logSp->warn(msg);
@@ -435,7 +435,7 @@ class LogManager final {
   }
 
   template <typename... Args>
-  inline void warn_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void warn_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
     auto logPtr = spdlog::get(name);
     if (logPtr) {
       logPtr->warn(fmt, std::forward<Args>(args)...);
@@ -443,7 +443,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void warn_name(const std::string& name, const T& msg) {
+  [[maybe_unused]] inline void warn_name(const std::string& name, const T& msg) {
     std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
     if (logPtr) {
       // logging to multi-sink logger
@@ -455,21 +455,21 @@ class LogManager final {
   // error
   //----------------------------------------------------------
   template <typename... Args>
-  inline void error(fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void error(fmt::format_string<Args...> fmt, Args&&... args) {
     if (m_logSp) {
       m_logSp->error(fmt, std::forward<Args>(args)...);
     }
   }
 
   template <typename T>
-  inline void error(const T& msg) {
+  [[maybe_unused]] inline void error(const T& msg) {
     if (m_logSp) {
       m_logSp->error(msg);
     }
   }
 
   template <typename... Args>
-  inline void error_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void error_if(bool flag, fmt::format_string<Args...> fmt, Args&&... args) {
     if (flag) {
       if (m_logSp) {
         m_logSp->error(fmt, std::forward<Args>(args)...);
@@ -478,7 +478,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void error_if(bool flag, const T& msg) {
+  [[maybe_unused]] inline void error_if(bool flag, const T& msg) {
     if (flag) {
       if (m_logSp) {
         m_logSp->error(msg);
@@ -487,7 +487,7 @@ class LogManager final {
   }
 
   template <typename... Args>
-  inline void error_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void error_name(const std::string& name, fmt::format_string<Args...> fmt, Args&&... args) {
     auto logPtr = spdlog::get(name);
     if (logPtr) {
       logPtr->error(fmt, std::forward<Args>(args)...);
@@ -495,7 +495,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void error_name(const std::string& name, const T& msg) {
+  [[maybe_unused]] inline void error_name(const std::string& name, const T& msg) {
     std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
     if (logPtr) {
       // logging to multi-sink logger
@@ -507,7 +507,7 @@ class LogManager final {
   // critical
   //----------------------------------------------------------
   template <typename... Args>
-  inline void critical(fmt::format_string<Args...> fmt, Args&&... args) {
+  [[maybe_unused]] inline void critical(fmt::format_string<Args...> fmt, Args&&... args) {
     if (m_logSp) {
       m_logSp->critical(fmt, std::forward<Args>(args)...);
     }
@@ -547,7 +547,7 @@ class LogManager final {
   }
 
   template <typename T>
-  inline void critical_name(const std::string& name, const T& msg) {
+  [[maybe_unused]] inline void critical_name(const std::string& name, const T& msg) {
     std::shared_ptr<spdlog::logger> logPtr = spdlog::get(name);
     if (logPtr) {
       // logging to multi-sink logger

--- a/lib/include/cppsl/log/loggableBase.hpp
+++ b/lib/include/cppsl/log/loggableBase.hpp
@@ -14,7 +14,7 @@
 //
 #include <memory>
 
-#include <cppsl/log/LogManager.hpp>
+#include "logManager.hpp"
 
 //----------------------------------------------------------------------------
 // Public defines and macros
@@ -39,13 +39,17 @@ class LoggableBase {
   /// @brief Constructor
   ///
   /// @param appenderPtr A shared pointer to a log appender
-  explicit LoggableBase(cppsl::log::LogManagerPtr appenderPtr) : m_logPtr(appenderPtr) {}
+  explicit LoggableBase(cppsl::log::LogManagerPtr appenderPtr) : m_logPtr(appenderPtr) {
+    if (!appenderPtr) {
+      throw std::invalid_argument("Log manager pointer cannot be null");
+    }
+  }
 
   /// @brief Destructor
   virtual ~LoggableBase() = default;
 
   /// @brief Pointer to the log appender
-  cppsl::log::LogManagerPtr m_logPtr;
+  [[maybe_unused]] cppsl::log::LogManagerPtr m_logPtr;
 };
 
 }  // namespace cppsl::log

--- a/lib/include/cppsl/log/loggableBase.hpp
+++ b/lib/include/cppsl/log/loggableBase.hpp
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * @file
+ * @brief  contains base abstract class for loggable objects.
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+//
+#include <memory>
+
+#include <cppsl/log/LogManager.hpp>
+
+//----------------------------------------------------------------------------
+// Public defines and macros
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public typedefs, structs, enums, unions and variables
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public Function Prototypes
+//----------------------------------------------------------------------------
+namespace cppsl::log {
+
+/// @brief LogAppender provides an interface for logging
+///
+/// @details
+/// This class acts as a base class for any logging appenders.
+/// It holds a pointer to a log appender instance.
+class LoggableBase {
+ protected:
+  /// @brief Constructor
+  ///
+  /// @param appenderPtr A shared pointer to a log appender
+  explicit LoggableBase(cppsl::log::LogManagerPtr appenderPtr) : m_logPtr(appenderPtr) {}
+
+  /// @brief Destructor
+  virtual ~LoggableBase() = default;
+
+  /// @brief Pointer to the log appender
+  cppsl::log::LogManagerPtr m_logPtr;
+};
+
+}  // namespace cppsl::log

--- a/lib/include/cppsl/threading/scopedFwdThread.hpp
+++ b/lib/include/cppsl/threading/scopedFwdThread.hpp
@@ -22,7 +22,8 @@ namespace cppsl::threading {
 template <typename Func, typename... Args>
 class ScopedFwdThread {
  public:
-  ScopedFwdThread(Func&& func, Args&&... args) : m_thread(std::forward<Func>(func), std::forward<Args>(args)...) {}
+  explicit ScopedFwdThread(Func&& func, Args&&... args)
+      : m_thread(std::forward<Func>(func), std::forward<Args>(args)...) {}
 
   ~ScopedFwdThread() {
     join();
@@ -40,7 +41,7 @@ class ScopedFwdThread {
     * @brief Check if the thread is terminated.
     * @return True if the thread is terminated, false otherwise.
     */
-  bool isTerminated() const {
+  [[nodiscard]] bool isTerminated() const {
     return m_terminated;
   }
 

--- a/lib/include/cppsl/threading/scopedFwdThread.hpp
+++ b/lib/include/cppsl/threading/scopedFwdThread.hpp
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * @file
+ * @brief  contains scoped thread class.
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <thread>
+
+namespace cppsl::threading {
+
+/**
+ * @brief A scoped thread class.
+ *
+ * The ScopedForwardThread class provides a simple wrapper around std::thread that joins the thread in the destructor.
+ * This ensures that the thread is joined when the ScopedForwardThread object goes out of scope.
+ */
+template <typename Func, typename... Args>
+class ScopedFwdThread {
+ public:
+  ScopedFwdThread(Func&& func, Args&&... args) : m_thread(std::forward<Func>(func), std::forward<Args>(args)...) {}
+
+  ~ScopedFwdThread() {
+    join();
+  }
+
+  /**
+   * @brief Retrieves the ID of the associated thread.
+   * @return The ID of the thread.
+   */
+  auto getThreadId() const {
+    return m_thread.get_id();
+  }
+
+  /**
+    * @brief Check if the thread is terminated.
+    * @return True if the thread is terminated, false otherwise.
+    */
+  bool isTerminated() const {
+    return m_terminated;
+  }
+
+  /**
+   * @brief Joins the thread if it is running and marks the thread as terminated.
+   * This function joins the underlying thread if it is running, using `std::thread::join()`.
+   * After joining, it sets the `m_terminated` flag to true.
+   * If the thread is already terminated or not joinable, this function does nothing.
+   */
+  void join() {
+    if (!m_terminated) {
+      if (m_thread.joinable()) {
+        m_thread.join();
+      }
+      m_terminated = true;
+    }
+  }
+
+ private:
+  bool m_terminated{false};  ///< flag to indicate if the thread has been terminated.
+  std::thread m_thread;      ///< thread object associated with this object.
+};
+
+/**
+ * @brief Extracts a function to create a ScopedForwardThread object.
+ *
+ * The `MakeScopedFwdThread` function is used to create a `ScopedForwardThread` object. This function takes a
+ * callable object (`Func`) and its arguments (`Args`) and forwards them to the constructor of `ScopedForwardThread`.
+ * The created `ScopedForwardThread` object is then returned.
+ * @return A `ScopedForwardThread` object.
+ */
+template <typename Func, typename... Args>
+ScopedFwdThread<Func, Args...> ConstructScopedFwdThread(Func&& func, Args&&... args) {
+  return ScopedFwdThread<Func, Args...>(std::forward<Func>(func), std::forward<Args>(args)...);
+}
+
+/**
+ * function template instantiateScopedFwdThread creates a std::unique_ptr to a ScopedFwdThread object.
+ * @param takes a function and a variadic list of arguments (using perfect forwarding).
+ * @return Returns a std::unique_ptr to a new ScopedFwdThread object instantiated with the provided function
+ * and arguments.
+ */
+template <typename FunctionType, typename... ArgumentTypes>
+std::unique_ptr<ScopedFwdThread<FunctionType, ArgumentTypes...>> MakeUniqueScopedFwdThread(
+    FunctionType&& function, ArgumentTypes&&... arguments) {
+  return std::make_unique<ScopedFwdThread<FunctionType, ArgumentTypes...>>(std::forward<FunctionType>(function),
+                                                                           std::forward<ArgumentTypes>(arguments)...);
+}
+
+}  // namespace cppsl::threading

--- a/lib/include/cppsl/threading/scopedThread.hpp
+++ b/lib/include/cppsl/threading/scopedThread.hpp
@@ -28,7 +28,7 @@ class ScopedThreadForwarding {
   /**
    * @brief move constructor.
    */
-  ScopedThreadForwarding(ScopedThreadForwarding&& other) {
+  ScopedThreadForwarding(ScopedThreadForwarding&& other) noexcept {
     m_thread = std::move(other.m_thread);
   }
 
@@ -83,7 +83,7 @@ class ScopedThreadForwarding {
    * @brief Get the thread identifier of the ScopedThread object.
    * @return The thread identifier of the underlying thread.
    */
-  auto get_id() const {
+  [[nodiscard]] auto get_id() const {
     return m_thread.get_id();
   }
 

--- a/lib/include/cppsl/threading/scopedThread.hpp
+++ b/lib/include/cppsl/threading/scopedThread.hpp
@@ -1,0 +1,113 @@
+/*************************************************************************/ /**
+ * @file
+ * @brief  contains scoped thread class.
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+#include <thread>
+
+namespace cppsl::threading {
+
+/**
+ * @brief A scoped thread class.
+ *
+ * The ScopedThread class provides a simple wrapper around std::thread that joins the thread in the destructor.
+ * This ensures that the thread is joined when the ScopedThread object goes out of scope.
+ */
+class ScopedThreadForwarding {
+ public:
+  /**
+   * @brief constructor
+   * @tparam Args Variadic template parameter representing the types of arguments passed to std::thread constructor.
+   */
+  template <class... Args>
+  explicit ScopedThreadForwarding(Args&&... args) : m_thread(std::forward<Args>(args)...) {}
+
+  /**
+   * @brief move constructor.
+   */
+  ScopedThreadForwarding(ScopedThreadForwarding&& other) {
+    m_thread = std::move(other.m_thread);
+  }
+
+  /**
+   * @brief assignment operator
+   * @param other The ScopedThread object to be assigned from.
+   * @return A reference to the current ScopedThread object after assignment.
+   */
+  ScopedThreadForwarding& operator=(ScopedThreadForwarding&& other) {
+    m_thread = std::move(other.m_thread);
+    return *this;
+  }
+
+  /**
+   * @brief Retrieves the reference to the underlying std::thread object.
+   * @return A reference to the std::thread object.
+   */
+  std::thread& operator*() {
+    return m_thread;
+  }
+
+  /**
+   * @brief Access the underlying `std::thread` object.
+   * @return A const reference to the underlying `std::thread` object.
+   */
+  std::thread const& operator*() const {
+    return m_thread;
+  }
+
+  /**
+   * @brief Overloaded arrow operator that returns a pointer to the std::thread object.
+   * The arrow operator (->) is overloaded to return a pointer to the std::thread object.
+   * This allows accessing the functions and member variables of the std::thread object 
+   * directly from a ScopedThread object.
+   * @return A pointer to the std::thread object.
+   */
+  std::thread* operator->() {
+    return &operator*();
+  }
+
+  /**
+   * @brief Returns a pointer to the underlying std::thread object.
+   * This function returns a const pointer to the underlying std::thread object associated with this ScopedThread object.
+   * It allows accessing the member functions and data of the std::thread object.
+   * @return A pointer to the underlying std::thread object.
+   */
+  std::thread const* operator->() const {
+    return &operator*();
+  }
+
+  /**
+   * @brief Get the thread identifier of the ScopedThread object.
+   * @return The thread identifier of the underlying thread.
+   */
+  auto get_id() const {
+    return m_thread.get_id();
+  }
+
+  /**
+   * @brief Joins the associated thread.
+   *
+   * The join() method checks if the thread is joinable and if so, it joins the thread. This means that the calling thread will wait until the associated thread completes its execution. If the thread is not joinable, no action is taken.
+   */
+  auto join() {
+    if (m_thread.joinable())
+      m_thread.join();
+  }
+
+  /**
+    * @brief Destructor for the ScopedThread class.
+    *
+    * This destructor joins the thread if it is joinable.
+    */
+  ~ScopedThreadForwarding() {
+    join();
+  }
+
+ private:
+  std::thread m_thread;  ///< The std::thread object associated with the ScopedThread object.
+};
+
+}  // namespace cppsl::threading

--- a/lib/include/cppsl/time/roundWatch.hpp
+++ b/lib/include/cppsl/time/roundWatch.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <chrono>
+#include <vector>
+
+#include <cppsl/time/stopTimer.hpp>
+
+namespace cppsl::time {
+
+/**
+ * This is a C++ template class called "RoundWatch" that extends the "StopTimer" class with a default template parameter
+ * of "std::chrono::milliseconds".
+ * The "RoundWatch" class has a few type aliases for convenience:
+ * "clock" and "time_point" are aliases for the clock and time_point types from the "StopTimer" class.
+ * The "State" alias is for the "State" enum from the "StopTimer" class.
+ *
+ * The class also has a nested struct called "LapDurations" which contains two durations: "total_time" and "split_time".
+ *
+ * The class provides a method called "StoreLap" which stores the lap durations if the clock state is running.
+ * The lap durations are calculated by subtracting the previous lap's total time from the current total time.
+ * The lap durations are then stored in a vector.
+ *
+ * The class also provides a method called "Reset" which clears the vector of lap durations.
+ * Lastly, the class has a method called "Laps" which returns a const reference to the vector of lap durations.
+ */
+template <typename duration = std::chrono::milliseconds>
+class RoundWatch : public StopTimer<duration> {
+  using ClockType = typename StopTimer<duration>::Clock;
+  using TimePointType = typename StopTimer<duration>::TimePoint;
+
+ public:
+  RoundWatch() = default;
+
+  /**
+   * @brief This struct represents the lap durations of a stopwatch.
+   *
+   * The LapDurations struct contains two duration values: total_time and split_time.
+   * The total_time represents the total elapsed time since the stopwatch started,
+   * and the split_time represents the time elapsed since the last lap.
+   */
+  struct LapDurations {
+    duration total_time;
+    duration split_time;
+  };
+
+  /**
+    * @brief Stores the lap durations if the timer is running.
+    *
+    * If the timer (StopTimer) is running, this function calculates the current lap duration
+    * by subtracting the previous lap's total time from the current total time. It then stores
+    * the calculated lap duration in a vector (lap_durations_).
+    */
+  void StoreLap() {
+    if (StopTimer<duration>::IsRunning()) {
+      lap_durations_.push_back(CalculateCurrentLapDuration());
+    }
+  }
+
+  /**
+   * @brief Resets the RoundWatch object by clearing the vector of lap durations.
+   *
+   * This function resets the RoundWatch object by clearing the vector of lap durations. After calling this function,
+   * the RoundWatch object will have no lap durations stored.
+   *
+   * @see Laps()
+   */
+  void Reset() noexcept {
+    lap_durations_.clear();
+  }
+
+  /**
+   * Returns a const reference to the vector of lap durations.
+   *
+   * @return The const reference to the vector of lap durations.
+   */
+  const std::vector<LapDurations>& Laps() const {
+    return lap_durations_;
+  }
+
+ private:
+  std::vector<LapDurations> lap_durations_;
+
+  /**
+   * @brief Calculates the current lap duration.
+   *
+   * This function calculates the current lap duration based on the total time elapsed since the stopwatch started.
+   * It returns a struct called LapDurations, which contains two durations: total_time and split_time.
+   * The total_time is the current total time elapsed, and the split_time is the time elapsed since the last lap.
+   * If there are no previous lap durations, the split_time is equal to the total_time.
+   *
+   * @return The current lap duration.
+   */
+  LapDurations CalculateCurrentLapDuration() {
+    LapDurations current;
+    current.total_time = StopTimer<duration>::ElapsedTime();
+
+    if (lap_durations_.empty()) {
+      current.split_time = current.total_time;
+    } else {
+      current.split_time = current.total_time - lap_durations_.back().total_time;
+    }
+
+    return current;
+  }
+};
+
+}  // namespace cppsl::time

--- a/lib/include/cppsl/time/roundWatch.hpp
+++ b/lib/include/cppsl/time/roundWatch.hpp
@@ -25,8 +25,8 @@ namespace cppsl::time {
  */
 template <typename duration = std::chrono::milliseconds>
 class RoundWatch : public StopTimer<duration> {
-  using ClockType = typename StopTimer<duration>::Clock;
-  using TimePointType = typename StopTimer<duration>::TimePoint;
+  using ClockType [[maybe_unused]] = typename StopTimer<duration>::Clock;
+  using TimePointType [[maybe_unused]] = typename StopTimer<duration>::TimePoint;
 
  public:
   RoundWatch() = default;
@@ -40,7 +40,7 @@ class RoundWatch : public StopTimer<duration> {
    */
   struct LapDurations {
     duration total_time;
-    duration split_time;
+    [[maybe_unused]] duration split_time;
   };
 
   /**
@@ -50,7 +50,7 @@ class RoundWatch : public StopTimer<duration> {
     * by subtracting the previous lap's total time from the current total time. It then stores
     * the calculated lap duration in a vector (lap_durations_).
     */
-  void StoreLap() {
+  [[maybe_unused]] void StoreLap() {
     if (StopTimer<duration>::IsRunning()) {
       lap_durations_.push_back(CalculateCurrentLapDuration());
     }
@@ -64,7 +64,7 @@ class RoundWatch : public StopTimer<duration> {
    *
    * @see Laps()
    */
-  void Reset() noexcept {
+  [[maybe_unused]] virtual void Reset() noexcept {
     lap_durations_.clear();
   }
 
@@ -73,7 +73,7 @@ class RoundWatch : public StopTimer<duration> {
    *
    * @return The const reference to the vector of lap durations.
    */
-  const std::vector<LapDurations>& Laps() const {
+  [[maybe_unused]] const std::vector<LapDurations>& Laps() const {
     return lap_durations_;
   }
 

--- a/lib/include/cppsl/time/stopTimer.hpp
+++ b/lib/include/cppsl/time/stopTimer.hpp
@@ -1,0 +1,186 @@
+/*************************************************************************/ /**
+* @file
+* @brief   steady stop watch "timer clock".
+* @details class contain classic timer
+*/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+#include <chrono>
+#include <optional>
+
+//----------------------------------------------------------------------------
+// Public Prototypes
+//----------------------------------------------------------------------------
+
+namespace cppsl::time {
+
+/**
+* @brief This is a easy stop timer in C++11 class.
+* Timer allows to set timeout and to check elapsed of timer
+*
+*/
+template <class TDuration = std::chrono::milliseconds>
+class StopTimer {
+ public:
+  /** types */
+  using Clock = std::chrono::steady_clock;
+  using TimePoint = std::chrono::time_point<StopTimer::Clock, TDuration>;
+
+  /**
+   * @brief constructors
+   */
+  StopTimer() = default;
+  StopTimer(TDuration timeout) : m_timeout_duration(timeout) {}
+
+  /**
+   * @brief get timeout
+   * @tparam TUnit - to-duration unit type
+   * @return duration in to-duration unit type
+   */
+  template <typename TUnit = TDuration>
+  [[nodiscard]] TUnit Timeout() const noexcept {
+    return std::chrono::duration_cast<TUnit>(m_timeout_duration);
+  }
+
+  /**
+   * @brief set timeout in duration unit
+   * @tparam TUnit - from-duration unit type
+   * @param timeout
+   */
+  template <typename TUnit = TDuration>
+  void SetTimeout(const TUnit& timeout) noexcept {
+    m_timeout_duration = std::chrono::duration_cast<TDuration>(timeout);
+  }
+
+  /**
+   * @brief is timer has been started (pushed)
+   * @return true if is running, otherwise - false
+   */
+  [[nodiscard]] bool IsRunning() const noexcept {
+    return m_is_running;
+  }
+
+  /**
+   * @brief stop running
+   * @details reset running flag and reset start point in timer
+   */
+  void Reset() noexcept {
+    m_is_running = false;
+    m_start_point = {};
+  }
+
+  /**
+   * @brief stop running
+   * @details stop running only without reset start point
+   */
+  void Stop() noexcept {
+    m_is_running = false;
+  }
+
+  /**
+   * @brief restart timer
+   * @details restart timer with setup start point to now time point
+   * @return start time point
+   */
+  TimePoint Start() noexcept {
+    m_is_running = true;
+    m_start_point = StopTimer::CurrentTime();
+    return m_start_point;
+  }
+
+  /**
+   * @brief start timer with setup timeout
+   * @details start timer with reset start point to now time point and new timeout
+   * @tparam TUnit - duration unit
+   * @param new_timeout - new timeout in duration unit
+   * @return start time point
+   */
+  template <typename TUnit = TDuration>
+  TimePoint Start(TUnit new_timeout) noexcept {
+    SetTimeout<TUnit>(new_timeout);
+    m_is_running = true;
+    m_start_point = StopTimer::CurrentTime();
+    return m_start_point;
+  }
+
+  /**
+   * @brief is timeout interval elapsed
+   * @brief check that defined timeout interval was elapsed
+   * @return optional boolean
+   *        1. is not running - hasn't value - std::nullopt
+   *        2. running but timeout is equal zero - true
+   *        3. running with timeout > zero: true if timeout elapsed, otherwise - false
+   */
+  [[nodiscard]] std::optional<bool> IsElapsed() noexcept {
+    if (!m_is_running) {
+      // timer is not running
+      return std::nullopt;
+    } else if (m_timeout_duration.count() == 0) {
+      // is running with 0 timeout
+      return true;
+    } else {
+      return (ElapsedTime() > m_timeout_duration);
+    }
+  }
+
+  /**
+   * @brief elapsed timeout
+   * @details elapsed timeout since start
+   * @tparam TUnit - duration unit
+   * @return elapsed time since start point
+   */
+  template <typename TUnit = TDuration>
+  [[nodiscard]] TUnit ElapsedTime() noexcept {
+    if (IsRunning()) {
+      return std::chrono::duration_cast<TUnit>(StopTimer::CurrentTime() - m_start_point);
+    } else {
+      return TUnit{};
+    }
+  }
+
+  /**
+   * @brief left time
+   * @details left time up to timeout point
+   * @tparam TUnit - duration unit
+   * @return left time
+   */
+  template <typename TUnit = TDuration>
+  [[nodiscard]] TUnit LeftTime() noexcept {
+    if (IsRunning()) {
+      return std::chrono::duration_cast<TUnit>(m_timeout_duration - ElapsedTime());
+    } else {
+      return TUnit{};
+    }
+  }
+
+  /**
+   * @brief current time for used clock from chrono
+   * @details static function used many times in class
+   * @return timepoint
+   */
+  [[nodiscard]] static inline TimePoint CurrentTime() noexcept {
+    return std::chrono::time_point_cast<TDuration>(Clock::now());
+  }
+
+ private:
+  StopTimer::TimePoint m_start_point{};  ///< start time point
+  TDuration m_timeout_duration{};        ///< timeout
+  bool m_is_running{false};              ///< is running
+};
+
+/**
+ * @brief useful types
+ * @details useful types for replace template type like standard library std::string
+ * TimerSec timerSec;
+ * TimerMs timerMs;
+ * TimerUs timerUs;
+ */
+using TimerSec = cppsl::time::StopTimer<std::chrono::seconds>;
+using TimerMs = cppsl::time::StopTimer<std::chrono::milliseconds>;
+using TimerUs = cppsl::time::StopTimer<std::chrono::microseconds>;
+
+}  // namespace cppsl::time

--- a/lib/include/cppsl/time/stopTimer.hpp
+++ b/lib/include/cppsl/time/stopTimer.hpp
@@ -68,7 +68,7 @@ class StopTimer {
    * @brief stop running
    * @details reset running flag and reset start point in timer
    */
-  void Reset() noexcept {
+  [[maybe_unused]] virtual void Reset() noexcept {
     m_is_running = false;
     m_start_point = {};
   }
@@ -77,7 +77,7 @@ class StopTimer {
    * @brief stop running
    * @details stop running only without reset start point
    */
-  void Stop() noexcept {
+  [[maybe_unused]] void Stop() noexcept {
     m_is_running = false;
   }
 

--- a/lib/include/cppsl/time/utilities.hpp
+++ b/lib/include/cppsl/time/utilities.hpp
@@ -113,8 +113,8 @@ inline std::tuple<Double, Double> TimePntToSecondsAndFractional(const TimePoint&
  */
 inline void FormatTimeToStream(std::ostringstream& oss, const std::tm* tm, const std::string& dateFormat,
                                double fractionalSeconds, std::size_t precision) {
-  oss << std::put_time(tm, dateFormat.c_str()) << std::setw(precision + 3) << std::setfill('0') << std::fixed
-      << std::setprecision(precision) << tm->tm_sec + fractionalSeconds;
+  oss << std::put_time(tm, dateFormat.c_str()) << std::setw(static_cast<int>(precision) + 3) << std::setfill('0')
+      << std::fixed << std::setprecision(static_cast<int>(precision)) << tm->tm_sec + fractionalSeconds;
 }
 
 /**
@@ -132,10 +132,10 @@ inline void FormatTimeToStream(std::ostringstream& oss, const std::tm* tm, const
  */
 template <typename Double = double, std::size_t Precision = std::numeric_limits<Double>::digits10, typename TimePoint>
   requires std::is_floating_point_v<Double> && (Precision <= std::numeric_limits<Double>::digits10)
-inline std::string TimePointToString(const TimePoint& timePoint) {
+[[maybe_unused]] inline std::string TimePointToString(const TimePoint& timePoint) {
   const std::string dateFormat = "%Y-%b-%d %H:%M:";
   const auto [wholeSeconds, fractionalSeconds] = TimePntToSecondsAndFractional<Double, TimePoint>(timePoint);
-  std::time_t tt = static_cast<std::time_t>(wholeSeconds);
+  auto tt = static_cast<std::time_t>(wholeSeconds);
 
   std::ostringstream oss;
   auto tm = std::localtime(&tt);
@@ -159,7 +159,7 @@ inline std::string TimePointToString(const TimePoint& timePoint) {
  * @throws std::invalid_argument If the input string is in an invalid format.
  */
 template <typename TimePoint>
-TimePoint TimePointFromString(const std::string& str) {
+[[maybe_unused]] TimePoint TimePointFromString(const std::string& str) {
   const std::string dateTimeFormat = "%Y-%b-%d %H:%M:%S";
 
   std::istringstream inputStream{str};
@@ -185,8 +185,8 @@ TimePoint TimePointFromString(const std::string& str) {
                                     std::chrono::high_resolution_clock::period::num);
   };
 
-  std::size_t zeconds = calculateFractionalSeconds(fractionalSeconds);
-  return timePoint += std::chrono::high_resolution_clock::duration(zeconds);
+  std::size_t seconds = calculateFractionalSeconds(fractionalSeconds);
+  return timePoint += std::chrono::high_resolution_clock::duration(seconds);
 }
 
 }  // namespace cppsl::time

--- a/lib/include/cppsl/time/utilities.hpp
+++ b/lib/include/cppsl/time/utilities.hpp
@@ -1,0 +1,192 @@
+/************************************************************************/ /**
+ * @file
+ * @brief  chrono functions
+ *
+ *   How to use:
+ *   ---
+ *
+ *   using std::chrono::system_clock;
+ *   auto now = system_clock::now();
+ *
+ *   std::clog << "==== " << TimePointToString(now) << std::endl;
+ *
+ *   using DD = std::chrono::duration<std::size_t, std::ratio<2, 3>>;
+ *   using TP = std::chrono::time_point<std::chrono::system_clock, DD>;
+ *
+ *   for (int i = 0; i <= 3; ++i)
+ *       std::clog << "==== " << TimePointToString(TP(DD(i))) << std::endl;
+ *
+ *   for (std::string s: {
+ *                "2017-May-01 00:10:15",
+ *                "2017-May-01 00:10:15.25",
+ *                "2017-Mar-01",
+ *                "1969-Dec-31 19:00:00.666666666666667",
+ *                "2018",      // underspecified - but succeeds as 2017-12-31
+ *                "1752-May-5",// out of range
+ *                "not a date",
+ *        }) {
+ *       try {
+ *           std::clog << "---- "
+ *                     << TimePointToString(TimePointFromString<system_clock::time_point>(s))
+ *                     << std::endl;
+ *       } catch (const std::exception &e) {
+ *           std::cerr << e.what() << std::endl;
+ *       }
+ *   }
+ *
+ *  ==== 2023-Jun-25 19:27:52.117357015609741
+ *  ==== 1970-Jan-01 01:00:00.000000000000000
+ *  ==== 1970-Jan-01 01:00:00.666666666666667
+ *  ==== 1970-Jan-01 01:00:01.333333333333333
+ *  ==== 1970-Jan-01 01:00:02.000000000000000
+ *  ---- 2017-May-01 01:10:15.000000000000000
+ *  ---- 2017-May-01 01:10:15.249999761581421
+ *  ---- 2017-Mar-01 00:00:00.000000000000000
+ *  ---- 1969-Dec-31 19:00:00.666666665998491
+ *  ---- 2017-Dec-31 00:00:00.000000000000000
+ *  ---- get_time
+ *  ---- get_time
+ *
+****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+//----------------------------------------------------------------------------
+// Public Prototypes
+//----------------------------------------------------------------------------
+
+namespace cppsl::time {
+
+/**
+ * @brief Convert a time point to seconds and fractional seconds.
+ *
+ * This function converts a given time point to seconds and fractional seconds.
+ * The time point can be of any duration type. The returned values are represented as a tuple
+ * containing two doubles - the seconds and the fractional part of seconds.
+ *
+ * @tparam Double The type of the doubles to represent seconds and fractional seconds.
+ * @tparam TimePoint The type of the time point to convert.
+ * @param timePoint The time point to convert to seconds and fractional seconds.
+ * @return std::tuple<Double, Double> A tuple containing the seconds and fractional seconds.
+ */
+template <typename Double, typename TimePoint>
+inline std::tuple<Double, Double> TimePntToSecondsAndFractional(const TimePoint& timePoint) {
+  Double seconds = Double(timePoint.time_since_epoch().count()) * TimePoint::period::num / TimePoint::period::den;
+  Double fractionalSeconds = std::modf(seconds, &seconds);
+  return {seconds, fractionalSeconds};
+}
+
+/**
+ * @brief Formats the given time into a specified date and time format.
+ *
+ * This function takes a `std::ostringstream` object as the output stream,
+ * a pointer to a `std::tm` object representing the time,
+ * a `std::string` specifying the date format,
+ * a `double` representing the fractional seconds,
+ * and a `std::size_t` specifying the precision of the fractional seconds.
+ *
+ * The function formats the time in the given date format using `std::put_time`,
+ * and appends the formatted date to the output stream.
+ * It then appends the fractional seconds with the specified precision to the output stream.
+ *
+ * @param oss The output `std::ostringstream` object.
+ * @param tm A pointer to a `std::tm` object representing the time.
+ * @param dateFormat The date format string.
+ * @param fractionalSeconds The fractional seconds.
+ * @param precision The precision of the fractional seconds.
+ *
+ * @return None.
+ */
+inline void FormatTimeToStream(std::ostringstream& oss, const std::tm* tm, const std::string& dateFormat,
+                               double fractionalSeconds, std::size_t precision) {
+  oss << std::put_time(tm, dateFormat.c_str()) << std::setw(precision + 3) << std::setfill('0') << std::fixed
+      << std::setprecision(precision) << tm->tm_sec + fractionalSeconds;
+}
+
+/**
+ * Converts a given time point to a string representation with specified precision.
+ *
+ * @tparam Double The desired floating point type for representing seconds.
+ * @tparam Precision The desired precision for fractional seconds.
+ * @tparam TimePoint The type of the time point to convert.
+ *
+ * @param timePoint The time point to convert to a string.
+ *
+ * @return A string representation of the given time point.
+ *
+ * @throws std::runtime_error if an error occurs during conversion.
+ */
+template <typename Double = double, std::size_t Precision = std::numeric_limits<Double>::digits10, typename TimePoint>
+  requires std::is_floating_point_v<Double> && (Precision <= std::numeric_limits<Double>::digits10)
+inline std::string TimePointToString(const TimePoint& timePoint) {
+  const std::string dateFormat = "%Y-%b-%d %H:%M:";
+  const auto [wholeSeconds, fractionalSeconds] = TimePntToSecondsAndFractional<Double, TimePoint>(timePoint);
+  std::time_t tt = static_cast<std::time_t>(wholeSeconds);
+
+  std::ostringstream oss;
+  auto tm = std::localtime(&tt);
+  if (!tm)
+    throw std::runtime_error(std::strerror(errno));
+
+  FormatTimeToStream(oss, tm, dateFormat, fractionalSeconds, Precision);
+
+  if (!oss)
+    throw std::runtime_error("time-point-to-string");
+
+  return oss.str();
+}
+
+/**
+ * Converts a string representation of a date and time to a TimePoint object.
+ *
+ * @param str The string to convert.
+ * @tparam TimePoint The type of TimePoint to create.
+ * @return The TimePoint object representing the specified date and time.
+ * @throws std::invalid_argument If the input string is in an invalid format.
+ */
+template <typename TimePoint>
+TimePoint TimePointFromString(const std::string& str) {
+  const std::string dateTimeFormat = "%Y-%b-%d %H:%M:%S";
+
+  std::istringstream inputStream{str};
+  std::tm timeStruct{};
+  double fractionalSeconds;
+
+  if (!(inputStream >> std::get_time(&timeStruct, dateTimeFormat.c_str()))) {
+    throw std::invalid_argument("Invalid date-time format");
+  }
+
+  TimePoint timePoint{std::chrono::seconds(std::mktime(&timeStruct))};
+
+  if (inputStream.eof()) {
+    return timePoint;
+  }
+
+  if (inputStream.peek() != '.' || !(inputStream >> fractionalSeconds)) {
+    throw std::invalid_argument("Invalid fractional seconds");
+  }
+
+  auto calculateFractionalSeconds = [](double zz) {
+    return static_cast<std::size_t>(zz * std::chrono::high_resolution_clock::period::den /
+                                    std::chrono::high_resolution_clock::period::num);
+  };
+
+  std::size_t zeconds = calculateFractionalSeconds(fractionalSeconds);
+  return timePoint += std::chrono::high_resolution_clock::duration(zeconds);
+}
+
+}  // namespace cppsl::time

--- a/lib/include/cppsl/utility/bytesSwap.hpp
+++ b/lib/include/cppsl/utility/bytesSwap.hpp
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * \file
+ * @brief  contains utilities, functions, templates
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+
+//----------------------------------------------------------------------------
+// Function Definitions
+//----------------------------------------------------------------------------
+
+namespace cppsl::utility {
+
+/**
+ * @class bytesSwap
+ * @brief A class for swapping bytes based on the endianness
+ *
+ * This class provides a static method for swapping bytes in a value based on the endianness of the machine,
+ * as well as an enum class for specifying the swap type.
+ */
+class bytesSwap {
+ public:
+  enum class SwapType {
+    BE,  // swap for big endian machines
+    LE,  // swap for little endian machines
+    AX,  // swap always, for f... strange float cases
+    NX   // swap never, for f... strange float cases
+  };
+
+  /**
+   * @brief A class for swapping bytes based on the endianness
+   *
+   * This class provides a static method for swapping bytes in a value based on the endianness of the machine,
+   * as well as an enum class for specifying the swap type.
+   */
+  template <typename T>
+  static T Swap(T val, SwapType swapType) {
+    if (swapType == SwapType::NX) {
+      return val;
+    }
+
+    T ret = val;
+    auto ptr = reinterpret_cast<uint8_t*>(&ret);
+    const auto size = sizeof(T);
+
+    if constexpr (std::endian::native == std::endian::big) {
+      if (swapType == SwapType::BE || swapType == SwapType::AX)
+        swapBytes(ptr, size);
+    } else if constexpr (std::endian::native == std::endian::little) {
+      if (swapType == SwapType::LE || swapType == SwapType::AX)
+        swapBytes(ptr, size);
+    }
+
+    return ret;
+  }
+
+  /**
+   * @fn swapBytes
+   * @brief A helper method to swap bytes
+   * Swaps the bytes in the given buffer.
+   *
+   * This function swaps the bytes in the given buffer of the specified size.
+   *
+   * @param ptr The pointer to the buffer of bytes to be swapped.
+   * @param size The size of the buffer in bytes.
+   * @return None.
+   */
+  static void swapBytes(uint8_t* ptr, size_t size) {
+    for (size_t i = 0; i < size / 2; ++i) {
+      std::swap(ptr[i], ptr[size - i - 1]);
+    }
+  }
+};
+
+}  // namespace cppsl::utility

--- a/lib/include/cppsl/utility/result.hpp
+++ b/lib/include/cppsl/utility/result.hpp
@@ -127,13 +127,13 @@ template <typename T>
 struct ResultVarVal : protected std::variant<std::monostate, T> {
   explicit constexpr ResultVarVal() noexcept = default;
 
-  constexpr ResultVarVal(const T& t) noexcept : std::variant<std::monostate, T>{t} {}
+  constexpr explicit ResultVarVal(const T& t) noexcept : std::variant<std::monostate, T>{t} {}
 
   /**
    * @brief Checks if the ResultVarVal object holds a valid value.
    * @return Returns true if the ResultVarVal object holds a valid value, false otherwise.
    */
-  constexpr bool valid() const noexcept {
+  [[nodiscard]] constexpr bool valid() const noexcept {
     return holds_value();
   }
 
@@ -141,7 +141,7 @@ struct ResultVarVal : protected std::variant<std::monostate, T> {
     * @brief Checks if the ResultVarVal object is valid.
     * @return True if the object is invalid, false otherwise.
     */
-  constexpr bool invalid() const noexcept {
+  [[nodiscard]] constexpr bool invalid() const noexcept {
     return !holds_value();
   }
 
@@ -155,7 +155,7 @@ struct ResultVarVal : protected std::variant<std::monostate, T> {
   }
 
  private:
-  constexpr bool holds_value() const noexcept {
+  [[nodiscard]] constexpr bool holds_value() const noexcept {
     return std::holds_alternative<T>(*this);
   }
 };
@@ -186,7 +186,7 @@ template <typename T>
 struct ResultOptional : protected std::optional<T> {
   explicit constexpr ResultOptional() noexcept = default;
 
-  constexpr ResultOptional(T const& t) noexcept : std::optional<T>{t} {}
+  constexpr explicit ResultOptional(T const& t) noexcept : std::optional<T>{t} {}
 
   [[nodiscard]] constexpr bool isValid() const noexcept {
     return hasValue();

--- a/lib/include/cppsl/utility/result.hpp
+++ b/lib/include/cppsl/utility/result.hpp
@@ -1,0 +1,208 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * \file
+ * @brief  contains result templates useful in new projects.
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+#include <optional>
+#include <variant>
+
+//----------------------------------------------------------------------------
+// Defines and macros
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Typedefs, structs, enums, unions and variables
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Public Prototypes
+//----------------------------------------------------------------------------
+
+namespace cppsl {
+
+/**
+ * @class ResultOptVal
+ * @brief A class that represents a result using std::optional.
+ *
+ * The ResultOptVal class provides methods for checking if the result is valid or invalid,
+ * retrieving the result value, and getting a default value if no result is present.
+ *
+ * It is important to note that this class does not inherit from a standard library class to avoid
+ * incorrect behavior.
+ * It is marked as final so that it cannot be used as a base class. Instead, it contains an std::optional
+ * member for storing the result value.
+ *
+ * @tparam T The type of the result value.
+ */
+template <typename T>
+class ResultOptVal final {
+ public:
+  /**
+   * @brief Constructor to initialize with a result value.
+   *
+   * @param t The result value to initialize with.
+   */
+  constexpr explicit ResultOptVal(const T& t) noexcept : opt_result_value_{t} {}
+
+  /**
+   * @brief Default constructor.
+   */
+  explicit constexpr ResultOptVal() noexcept = default;
+
+  /**
+   * @brief Check if the result value is valid.
+   *
+   * @return true if the result value is valid, false otherwise.
+   */
+  [[nodiscard]] constexpr bool IsValid() const noexcept {
+    return opt_result_value_.has_value();
+  }
+
+  /**
+   * @brief Check if the result value is invalid.
+   *
+   * @return true if the result value is invalid, false otherwise.
+   */
+  [[nodiscard]] constexpr bool IsInvalid() const noexcept {
+    return !IsValid();
+  }
+
+  /**
+   * @brief Retrieves the result value.
+   *
+   * @return The result value.
+   */
+  [[nodiscard]] constexpr T GetValue() const {
+    return opt_result_value_.value();
+  }
+
+  /**
+   * @brief Retrieves the result value or a default value if no result is present.
+   *
+   * @return The result value, or a default-constructed value of type `T` if no result is present.
+   */
+  [[nodiscard]] T GetValueOrDefault() const noexcept {
+    return opt_result_value_.value_or(T());
+  }
+
+ private:
+  std::optional<T> opt_result_value_;
+};
+;
+
+/**
+ * @class ResultVarVal
+ * @brief A class that represents a result variable value.
+ *
+ * The ResultVarVal class is a template class that represents a result variable value. It is derived from std::variant<std::monostate, T>, where T is the type of the value.
+ *
+ * The ResultVarVal class provides constructors and member functions to determine the validity of the value, retrieve the value, and check if the object holds a valid value.
+ *
+ * Example Usage:
+ *
+ * @code
+ *
+ * // Create a ResultVarVal object with an integer value
+ * ResultVarVal<int> result(10);
+ *
+ * // Check if the result is valid
+ * if(result.valid()) {
+ *     ...
+ * }
+ *
+ * // Retrieve the value
+ * int value = result.get();
+ *
+ * @endcode
+ *
+ * @tparam T The type of the value
+ */
+template <typename T>
+struct ResultVarVal : protected std::variant<std::monostate, T> {
+  explicit constexpr ResultVarVal() noexcept = default;
+
+  constexpr ResultVarVal(const T& t) noexcept : std::variant<std::monostate, T>{t} {}
+
+  /**
+   * @brief Checks if the ResultVarVal object holds a valid value.
+   * @return Returns true if the ResultVarVal object holds a valid value, false otherwise.
+   */
+  constexpr bool valid() const noexcept {
+    return holds_value();
+  }
+
+  /**
+    * @brief Checks if the ResultVarVal object is valid.
+    * @return True if the object is invalid, false otherwise.
+    */
+  constexpr bool invalid() const noexcept {
+    return !holds_value();
+  }
+
+  /**
+    * Retrieves the value of the ResultVarVal object.
+    * @tparam T The type of the value
+    * @return The stored value if valid, otherwise a default-constructed value of type T
+    */
+  constexpr auto get() const noexcept -> T {
+    return (holds_value() ? std::get<T>(*this) : T());
+  }
+
+ private:
+  constexpr bool holds_value() const noexcept {
+    return std::holds_alternative<T>(*this);
+  }
+};
+
+/**
+ * @class ResultOptional
+ *
+ * @brief Result based on std::optional
+ *
+ * The ResultOptional class is a templated class that is based on std::optional. It provides a result type that either contains
+ * a valid value of type T or is empty. This class is designed to be a wrapper around std::optional and adds some
+ * convenience methods for checking the validity of the result and accessing the value.
+ *
+ * Usage:
+ * ```
+ * ResultOptional<int> result(42);
+ * if (result.valid()) {
+ *     int value = result.get();
+ *     // Do something with value
+ * } else {
+ *     // Handle error case
+ * }
+ * ```
+ *
+ * @tparam T The type of the value contained in the result
+ */
+template <typename T>
+struct ResultOptional : protected std::optional<T> {
+  explicit constexpr ResultOptional() noexcept = default;
+
+  constexpr ResultOptional(T const& t) noexcept : std::optional<T>{t} {}
+
+  [[nodiscard]] constexpr bool isValid() const noexcept {
+    return hasValue();
+  }
+
+  [[nodiscard]] constexpr bool isInvalid() const noexcept {
+    return !isValid();
+  }
+
+  [[nodiscard]] constexpr auto value() const noexcept -> T {
+    return std::optional<T>::value_or(T());
+  }
+
+ private:
+  [[nodiscard]] constexpr bool hasValue() const noexcept {
+    return std::optional<T>::has_value();
+  }
+};
+}  // namespace cppsl

--- a/lib/include/cppsl/utility/string_utility.hpp
+++ b/lib/include/cppsl/utility/string_utility.hpp
@@ -1,0 +1,390 @@
+/* SPDX-License-Identifier: MIT */
+
+/*************************************************************************/ /**
+ * \file
+ * @brief  contains other util-functions.
+ * @ingroup C++ support library
+ *****************************************************************************/
+
+#pragma once
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+//----------------------------------------------------------------------------
+// Public Function Prototypes
+//----------------------------------------------------------------------------
+
+namespace cppsl::utility {
+
+/**
+ * @brief Converts a hexadecimal character to its corresponding byte value.
+ * @param input The hexadecimal character to be converted.
+ * @return The byte value of the input hexadecimal character.
+ * @throws std::range_error If the input character is not a valid hexadecimal character.
+ *
+ * @example
+ * ```cpp
+ * char hexChar = 'A';
+ * std::uint8_t byte = HexToByte(hexChar);
+ * // byte is now 10
+ * ```
+ */
+[[maybe_unused]] constexpr std::uint8_t HexToByte(char input) {
+  if (input >= '0' && input <= '9') {
+    return static_cast<std::uint8_t>(input - '0');
+  }
+  if (input >= 'A' && input <= 'F') {
+    return static_cast<std::uint8_t>(input - 'A' + 10);
+  }
+  if (input >= 'a' && input <= 'f') {
+    return static_cast<std::uint8_t>(input - 'a' + 10);
+  }
+  throw std::range_error(std::string("cannot convert HEX character ") + std::to_string(input));
+}
+
+/**
+ * @brief Converts two hexadecimal characters to a single byte value.
+ * @param High The character representing the high nibble of the byte.
+ * @param Low The character representing the low nibble of the byte.
+ * @return The combined byte value of the high and low nibbles.
+ * @throws std::range_error If either input character is not a valid hexadecimal character.
+ *
+ * @example
+ * ```cpp
+ * char highNibble = 'A';
+ * char lowNibble = '7';
+ * std::uint8_t byte = HexCharsToByte(highNibble, lowNibble);
+ * // byte is now 167
+ * ```
+ */
+[[maybe_unused]] constexpr std::uint8_t HexCharsToByte(char High, char Low) {
+  return (HexToByte(High) << 4) | (HexToByte(Low));
+}
+
+/**
+ * @brief Converts a hexadecimal string to a sequence of bytes.
+ *
+ * This function takes a null-terminated hexadecimal string and converts it to a sequence of bytes.
+ * Each pair of consecutive characters in the string represents a single byte in hexadecimal format.
+ * The resulting byte sequence is stored in an output array of type TypeOutput.
+ * The length of the output array should be at least half the length of the input string,
+ * to accommodate the conversion of each pair of characters into a byte.
+ *
+ * @tparam TypeOutput The type of the output array. It must be an array type.
+ * @tparam Length The length of the input string, including the null terminator.
+ * @tparam Index A parameter pack of compile-time indices used for expanding the function parameter pack.
+ * @param Input The null-terminated input hexadecimal string.
+ * @param seq A std::index_sequence used for expanding the function parameter pack.
+ * @return The resulting byte sequence stored in the output array.
+ *
+ * @example
+ * ```
+ * const char* hexString = "48656C6C6F"; // "Hello" in hexadecimal
+ * std::array<std::uint8_t, 5> bytes = HexStringToBytes<std::array<std::uint8_t, 5>>(hexString, std::make_index_sequence<10>{});
+ * // bytes is now {72, 101, 108, 108, 111}
+ * ```
+ *
+ * @remark The input string must consist only of valid hexadecimal characters (0-9, A-F, a-f).
+ * If any input character is not a valid hexadecimal character, a std::range_error exception is thrown.
+ * The output array must have enough capacity to store the resulting byte sequence.
+ *
+ * @see HexCharsToByte
+ * @see HexToByte
+ */
+template <typename TypeOutput, std::size_t Length, std::size_t... Index>
+constexpr TypeOutput HexStringToBytes(const char (&Input)[Length], const std::index_sequence<Index...>&) {
+  return TypeOutput{HexCharsToByte(Input[(Index * 2)], Input[((Index * 2) + 1)])...};
+}
+
+/**
+ * @brief Converts a hex string to byte representation.
+ *
+ * This function converts a null-terminated hex string to a byte representation. The byte representation is of a specified output type (`TypeOutput`).
+ * The length of the input string (`Length`) must be an even number.
+ *
+ * @tparam TypeOutput The output type of the byte representation.
+ * @tparam Length The length of the input string.
+ * @param Input The null-terminated hex string to convert.
+ * @return The byte representation of the hex string.
+ */
+template <typename TypeOutput, std::size_t Length>
+constexpr TypeOutput HexStringToBytes(const char (&Input)[Length]) {
+  return HexStringToBytes<TypeOutput>(Input, std::make_index_sequence<(Length / 2)>{});
+}
+
+/**
+ * @brief Checks if a value is within a specified range.
+ *
+ * This template function checks if the given value is within the specified range.
+ * The range is defined by the lower bound (low) and the upper bound (high) values.
+ * The function returns true if the value is within the range, and false otherwise.
+ *
+ * @tparam T The type of the value and the range bounds.
+ * @param value The value to check if it is within the range.
+ * @param low The lower bound of the range.
+ * @param high The upper bound of the range.
+ * @return True if the value is within the range, false otherwise.
+ */
+template <typename T>
+bool IsInRange(const T& value, const T& low, const T& high) noexcept {
+  return !(value < low) && !(high < value);
+}
+
+/**
+ * @brief Checks if a value is within a specified range using comparator function
+ *
+ * This function compares a given value with a low and high limit using a provided comparator.
+ * It returns true if the value is not less than the low limit and is less than the high limit according to the comparator,
+ * otherwise it returns false.
+ *
+ * @tparam T The type of the value being checked.
+ * @tparam R The type of the low and high limits.
+ * @tparam Comparator The type of the comparator function.
+ * @param value The value being checked.
+ * @param low The lower limit of the range.
+ * @param high The upper limit of the range.
+ * @param comp The comparator function used to compare the value with the limits.
+ * @return Returns true if the value is within the range, false otherwise.
+ */
+template <typename T, typename R, typename Comparator>
+bool IsInRange(const T& value, const R& low, const R& high, Comparator comp) {
+  return !comp(value, low) && comp(value, high);
+}
+
+/**
+ * Converts a vector of unsigned characters to a string.
+ *
+ * The function takes a vector of unsigned characters as input and converts it to a string by
+ * mapping each character to a corresponding character in the string. The resulting string is
+ * then returned.
+ *
+ * @param bytes A vector containing the unsigned characters to convert to a string.
+ * @return The string representation of the input vector of unsigned characters.
+ */
+[[maybe_unused]] static std::string ByteVectorToString(const std::vector<unsigned char>& bytes) {
+  std::string str;
+  std::transform(std::begin(bytes), std::end(bytes), std::back_inserter(str), [](uint8_t c) {
+    return char(c);
+  });
+  return str;
+}
+
+/**
+ * @brief Compares two strings case-insensitively.
+ *
+ * This function compares two strings case-insensitively by converting
+ * each character to uppercase using std::toupper, and then comparing
+ * the resulting characters. If the sizes of the strings are different,
+ * the function returns false immediately. Otherwise, it compares each
+ * character of the strings one by one, stopping the comparison and
+ * returning false if any characters are not equal in the case-insensitive
+ * sense. If all characters are equal, the function returns true.
+ *
+ * @param str1 The first string to be compared.
+ * @param str2 The second string to be compared.
+ * @return True if the strings are case-insensitively equal, false otherwise.
+ *
+ * @note The function treats Unicode case-folding equivalences as equal.
+ * @note The function is case-insensitive, but it assumes that the strings
+ * contain only ASCII characters. If the strings contain non-ASCII
+ * characters, the behavior is undefined.
+ * @note The function is marked as [[maybe_unused]] to suppress compiler
+ * warnings about unused functions.
+ */
+[[maybe_unused]] static bool StrCmpNoCase(const std::string& str1, const std::string& str2) {
+  if (str1.size() != str2.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < str1.size(); ++i) {
+    if (std::toupper(str1[i]) != std::toupper(str2[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Safely compares two null-terminated C-style strings.
+ *
+ * @param str1 First string pointer.
+ * @param str2 Second string pointer.
+ * @return An integer less than, equal to, or greater than zero if str1 is found,
+ *         respectively, to be less than, to match, or be greater than str2.
+ */
+template <typename T>
+int StrCmpCSafe(T* str1, T* str2) noexcept {
+  if (str1 == nullptr && str2 == nullptr) {
+    return 0;
+  } else if (str1 == nullptr) {
+    return -1;
+  } else if (str2 == nullptr) {
+    return 1;
+  } else {
+    return std::strcmp(str1, str2);
+  }
+}
+
+/**
+ * @brief Copies a C-style string and returns a unique_ptr to the copy.
+ *
+ * This function takes a C-style string, `str`, as input and creates a copy of it. The copy is then
+ * stored in a unique_ptr and returned. If the input string is null, a null unique_ptr is returned.
+ *
+ * @tparam CharT The character type of the string.
+ * @param str The input C-style string to be copied.
+ * @return std::unique_ptr<CharT[]> A unique_ptr pointing to the copy of the input string.
+ *
+ * @remarks The function assumes that the input string is null-terminated.
+ *          The resulting copy will also be null-terminated.
+ *          The function allocates memory dynamically, so the caller is responsible for ensuring
+ *          proper deallocation of the memory when it is no longer needed.
+ *          If the input string is null, a null unique_ptr will be returned.
+ *
+ * @see std::unique_ptr
+ * @see std::char_traits
+ * @see std::copy
+ */
+template <typename CharT>
+std::unique_ptr<CharT[]> StrDupSafeUnique(const CharT* str) {
+  if (!str) {
+    return nullptr;  // Handle null string input
+  }
+
+  size_t len = std::char_traits<CharT>::length(str);
+  std::unique_ptr<CharT[]> copy(new CharT[len + 1]);
+
+  std::copy(str, str + len, copy.get());
+  copy[len] = CharT();  // Null-terminate the new string
+
+  return copy;
+}
+
+/**
+ * @brief Safely duplicates a string.
+ *
+ * This function duplicates a character string by allocating memory for a new string and copying the contents of the
+ * input string into it. It handles null pointer input and memory allocation failure by returning nullptr. The new
+ * string is null-terminated.
+ *
+ * @tparam CharT typename of the input string characters.
+ * @param str The input string to be duplicated.
+ * @return CharT* A pointer to the duplicated string. It is the responsibility of the caller to free the allocated memory.
+ *
+ * @note The function uses the `std::char_traits<CharT>::length` function to calculate the length of the input string.
+ * @note The function uses the `std::copy` function to copy the contents of the input string into the new string.
+ * @note The new string is null-terminated by assigning a null character (`CharT()`) at the end.
+ * @note If the input string is null, the function returns nullptr.
+ * @note If memory allocation fails, the function returns nullptr.
+ */
+template <typename CharT>
+CharT* StrDupSafe(const CharT* str) noexcept {
+  if (!str) {
+    return nullptr;  // Handle null string input
+  }
+
+  size_t len = std::char_traits<CharT>::length(str);
+  size_t totalLen = len + 1;
+
+  try {
+    CharT* copiedStr = new CharT[totalLen];
+    std::copy(str, str + len, copiedStr);
+    copiedStr[len] = CharT();  // Null-terminate the new string
+    return copiedStr;
+  } catch (const std::bad_alloc&) {
+    return nullptr;  // Handle memory allocation failure
+  }
+}
+
+/**
+ * @brief Trims leading whitespaces from the input string.
+ * @param str The input string from which leading whitespaces should be removed.
+ * @return A new string with leading whitespaces removed.
+ */
+[[nodiscard, maybe_unused]] static std::string ltrim(const std::string& str) {
+  auto start = std::find_if_not(str.begin(), str.end(), [](unsigned char ch) {
+    return std::isspace(ch);
+  });
+  return std::string(start, str.end());
+}
+
+/**
+ * @brief Trims trailing whitespaces from the given string.
+ * @param str The input string to be trimmed.
+ * @return A new string with trailing whitespaces removed.
+ */
+[[nodiscard, maybe_unused]] static std::string rtrim(const std::string& str) {
+  auto end = std::find_if(str.rbegin(), str.rend(), [](unsigned char ch) {
+               return !std::isspace(ch);
+             }).base();
+  return std::string(str.begin(), end);
+}
+
+/**
+ * @brief Trims leading and trailing whitespaces from a string.
+ * @param str The input string that needs to be trimmed.
+ * @return A new string with leading and trailing whitespaces removed.
+ */
+[[nodiscard, maybe_unused]] static std::string trim(const std::string& str) {
+  auto start = std::find_if_not(str.begin(), str.end(), [](unsigned char ch) {
+    return std::isspace(ch);
+  });
+
+  auto end = std::find_if_not(str.rbegin(), str.rend(), [](unsigned char ch) {
+               return std::isspace(ch);
+             }).base();
+
+  return (start < end) ? std::string(start, end) : std::string();
+}
+
+/**
+ * Tokenizes the given string using the specified delimiters.
+ *
+ * @param str The input string to be tokenized.
+ * @return A vector of tokens extracted from the input string.
+ * @example
+ * std::string sAddr=
+ *    "$CHK:SameVal:Off=3:BIT=5:VAL=0; $CHK:InBand:Off=104:INT8:MIN=-64:MAX=64:RISE=2:LOWER=1; "
+ *    "$ACK:AckAny:Off=104:INT8:LATCH:VAL=0; $ERR:SameVal:Off=3:BIT=4:VAL=1}";
+ *     std::vector<std::string> tokens = splitString(input, "; \t\n\r");
+ *
+ * // Print the tokens
+ * for (const auto& token : tokens) {
+ *    std::cout << "[" << token << "]" << std::endl;
+ * }
+ *
+ * Output:
+ *  [$CHK:SameVal:Off=3:BIT=7:VAL=1]
+ *  [$CHK:SameVal:Off=3:BIT=5:VAL=0]
+ *  [$ACK:AckAny:Off=104:INT8:LATCH:VAL=0]
+ *  [$ERR:SameVal:Off=3:BIT=4:VAL=1]
+ */
+[[nodiscard, maybe_unused]] static std::vector<std::string> splitString(const std::string& str, const std::string& delimiters) {
+  std::vector<std::string> tokens;
+  size_t start = 0;
+  size_t end = 0;
+
+  while ((end = str.find_first_of(delimiters, start)) != std::string::npos) {
+    if (end != start) {
+      tokens.push_back(str.substr(start, end - start));
+    }
+    start = end + 1;
+  }
+
+  if (start < str.size()) {
+    tokens.push_back(str.substr(start));
+  }
+
+  return tokens;
+}
+
+}  // namespace cppsl::utility

--- a/lib/include/cppsl/utility/string_utility.hpp
+++ b/lib/include/cppsl/utility/string_utility.hpp
@@ -136,8 +136,8 @@ constexpr TypeOutput HexStringToBytes(const char (&Input)[Length]) {
  * @return True if the value is within the range, false otherwise.
  */
 template <typename T>
-bool IsInRange(const T& value, const T& low, const T& high) noexcept {
-  return !(value < low) && !(high < value);
+[[maybe_unused]] bool IsInRange(const T& value, const T& low, const T& high) noexcept {
+  return value >= low && high >= value;
 }
 
 /**
@@ -157,7 +157,7 @@ bool IsInRange(const T& value, const T& low, const T& high) noexcept {
  * @return Returns true if the value is within the range, false otherwise.
  */
 template <typename T, typename R, typename Comparator>
-bool IsInRange(const T& value, const R& low, const R& high, Comparator comp) {
+[[maybe_unused]] bool IsInRange(const T& value, const R& low, const R& high, Comparator comp) {
   return !comp(value, low) && comp(value, high);
 }
 
@@ -222,7 +222,7 @@ bool IsInRange(const T& value, const R& low, const R& high, Comparator comp) {
  *         respectively, to be less than, to match, or be greater than str2.
  */
 template <typename T>
-int StrCmpCSafe(T* str1, T* str2) noexcept {
+[[maybe_unused]] int StrCmpCSafe(T* str1, T* str2) noexcept {
   if (str1 == nullptr && str2 == nullptr) {
     return 0;
   } else if (str1 == nullptr) {
@@ -255,7 +255,7 @@ int StrCmpCSafe(T* str1, T* str2) noexcept {
  * @see std::copy
  */
 template <typename CharT>
-std::unique_ptr<CharT[]> StrDupSafeUnique(const CharT* str) {
+[[maybe_unused]] std::unique_ptr<CharT[]> StrDupSafeUnique(const CharT* str) {
   if (!str) {
     return nullptr;  // Handle null string input
   }
@@ -287,7 +287,7 @@ std::unique_ptr<CharT[]> StrDupSafeUnique(const CharT* str) {
  * @note If memory allocation fails, the function returns nullptr.
  */
 template <typename CharT>
-CharT* StrDupSafe(const CharT* str) noexcept {
+[[maybe_unused]] CharT* StrDupSafe(const CharT* str) noexcept {
   if (!str) {
     return nullptr;  // Handle null string input
   }
@@ -296,7 +296,7 @@ CharT* StrDupSafe(const CharT* str) noexcept {
   size_t totalLen = len + 1;
 
   try {
-    CharT* copiedStr = new CharT[totalLen];
+    auto copiedStr = new CharT[totalLen];
     std::copy(str, str + len, copiedStr);
     copiedStr[len] = CharT();  // Null-terminate the new string
     return copiedStr;
@@ -310,11 +310,11 @@ CharT* StrDupSafe(const CharT* str) noexcept {
  * @param str The input string from which leading whitespaces should be removed.
  * @return A new string with leading whitespaces removed.
  */
-[[nodiscard, maybe_unused]] static std::string ltrim(const std::string& str) {
+[[nodiscard, maybe_unused]] static std::string TrimLeadingWhitespaces(const std::string& str) {
   auto start = std::find_if_not(str.begin(), str.end(), [](unsigned char ch) {
     return std::isspace(ch);
   });
-  return std::string(start, str.end());
+  return {start, str.end()};
 }
 
 /**
@@ -322,11 +322,11 @@ CharT* StrDupSafe(const CharT* str) noexcept {
  * @param str The input string to be trimmed.
  * @return A new string with trailing whitespaces removed.
  */
-[[nodiscard, maybe_unused]] static std::string rtrim(const std::string& str) {
+[[nodiscard, maybe_unused]] static std::string TrimTrailingWhitespaces(const std::string& str) {
   auto end = std::find_if(str.rbegin(), str.rend(), [](unsigned char ch) {
                return !std::isspace(ch);
              }).base();
-  return std::string(str.begin(), end);
+  return {str.begin(), end};
 }
 
 /**
@@ -334,7 +334,7 @@ CharT* StrDupSafe(const CharT* str) noexcept {
  * @param str The input string that needs to be trimmed.
  * @return A new string with leading and trailing whitespaces removed.
  */
-[[nodiscard, maybe_unused]] static std::string trim(const std::string& str) {
+[[nodiscard, maybe_unused]] static std::string TrimWhitespace(const std::string& str) {
   auto start = std::find_if_not(str.begin(), str.end(), [](unsigned char ch) {
     return std::isspace(ch);
   });
@@ -355,7 +355,7 @@ CharT* StrDupSafe(const CharT* str) noexcept {
  * std::string sAddr=
  *    "$CHK:SameVal:Off=3:BIT=5:VAL=0; $CHK:InBand:Off=104:INT8:MIN=-64:MAX=64:RISE=2:LOWER=1; "
  *    "$ACK:AckAny:Off=104:INT8:LATCH:VAL=0; $ERR:SameVal:Off=3:BIT=4:VAL=1}";
- *     std::vector<std::string> tokens = splitString(input, "; \t\n\r");
+ *     std::vector<std::string> tokens = SplitString(input, "; \t\n\r");
  *
  * // Print the tokens
  * for (const auto& token : tokens) {
@@ -368,7 +368,8 @@ CharT* StrDupSafe(const CharT* str) noexcept {
  *  [$ACK:AckAny:Off=104:INT8:LATCH:VAL=0]
  *  [$ERR:SameVal:Off=3:BIT=4:VAL=1]
  */
-[[nodiscard, maybe_unused]] static std::vector<std::string> splitString(const std::string& str, const std::string& delimiters) {
+[[nodiscard, maybe_unused]] static std::vector<std::string> SplitString(const std::string& str,
+                                                                        const std::string& delimiters) {
   std::vector<std::string> tokens;
   size_t start = 0;
   size_t end = 0;

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -1,0 +1,83 @@
+# Set project name
+set(TargetName cppsl)
+
+set(TARGET_INCLUDE_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+file(GLOB_RECURSE TARGET_HEADERS ${TARGET_INCLUDE_FOLDER}/*.hpp)
+file(GLOB_RECURSE TARGET_SOURCES *.cpp)
+
+# Add executable
+add_library(${TargetName} ${TARGET_SOURCES} ${TARGET_HEADERS})
+
+# Add SOVERSION
+set_target_properties(${TargetName} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+# Find dependencies
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
+
+# Add include directories
+target_include_directories(
+   ${TargetName}
+   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+   PUBLIC "$<BUILD_INTERFACE:${TARGET_INCLUDE_FOLDER}>"
+   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+# Retain include structure when installing
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/container DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/file DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/log DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/net DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/process DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/threading DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/time DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+install(DIRECTORY ${TARGET_INCLUDE_FOLDER}/${TargetName}/utility DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName})
+
+target_link_libraries(${TargetName} PRIVATE Threads::Threads fmt::fmt spdlog::spdlog ${PROCPS_LINK_LIBRARIES})
+
+if (BUILD_SHARED_LIBS)
+  # define export targets and file paths
+  set(EXPORT_TARGETS ${TargetName})
+  set(EXPORT_TARGETS_DIR ${CMAKE_INSTALL_LIBDIR}/${TargetName})
+  set(EXPORT_TARGETS_FILE ${TargetName}Targets.cmake)
+  set(EXPORT_TARGETS_FILE_PATH ${EXPORT_TARGETS_DIR}/${EXPORT_TARGETS_FILE})
+
+  # install build information for applications
+  install(
+     TARGETS ${EXPORT_TARGETS}
+     EXPORT ${TargetName}Targets
+     DESTINATION ${EXPORT_TARGETS_DIR}
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TargetName}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+  install(
+     EXPORT ${TargetName}Targets
+     FILE ${EXPORT_TARGETS_FILE}
+     DESTINATION ${EXPORT_TARGETS_DIR}
+  )
+
+  include(CMakePackageConfigHelpers)
+  # generate the config file that includes the exports
+  configure_package_config_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+     "${CMAKE_CURRENT_BINARY_DIR}/${TargetName}Config.cmake"
+     INSTALL_DESTINATION "${EXPORT_TARGETS_DIR}"
+  )
+  write_basic_package_version_file(
+     "${CMAKE_CURRENT_BINARY_DIR}/${TargetName}ConfigVersion.cmake"
+     VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+     COMPATIBILITY AnyNewerVersion
+  )
+  install(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/${TargetName}Config.cmake
+     ${CMAKE_CURRENT_BINARY_DIR}/${TargetName}ConfigVersion.cmake
+     DESTINATION ${EXPORT_TARGETS_DIR}
+  )
+
+  # export build information for non-install
+  export(
+     EXPORT ${TargetName}Targets
+     FILE ${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_TARGETS_FILE}
+  )
+endif ()

--- a/lib/src/Config.cmake.in
+++ b/lib/src/Config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+# Find required dependencies
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
+
+pkg_search_module(PROCPS REQUIRED libproc2 libprocps)
+pkg_check_modules(PROCPS REQUIRED ${PROCPS_MODULE_NAME})
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake" )

--- a/lib/src/Config.cmake.in
+++ b/lib/src/Config.cmake.in
@@ -4,7 +4,4 @@
 find_package(spdlog REQUIRED)
 find_package(fmt REQUIRED)
 
-pkg_search_module(PROCPS REQUIRED libproc2 libprocps)
-pkg_check_modules(PROCPS REQUIRED ${PROCPS_MODULE_NAME})
-
 include ( "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake" )

--- a/lib/src/log/LoggingManager.cpp
+++ b/lib/src/log/LoggingManager.cpp
@@ -42,14 +42,13 @@ bool LogManager::openLogger(spdlog::level::level_enum level) {
     if (!m_logSp)
       throw spdlog::spdlog_ex("no logging manager instance created");
 
-    m_logSp->set_level(level);
-
     // or you can even set multi_sink logger as default logger
     if (m_logSp->sinks().empty()) {
-      if (!add_console_sink(OutputLog::err, Colored::color, level)) {
-        throw spdlog::spdlog_ex("cannot add console sink");
-      }
+      throw spdlog::spdlog_ex("no sinks added to logger");
     }
+
+    m_logSp->set_level(level);
+
     // register logger
     spdlog::register_logger(m_logSp);
     return true;

--- a/lib/src/log/LoggingManager.cpp
+++ b/lib/src/log/LoggingManager.cpp
@@ -1,0 +1,331 @@
+/*************************************************************************/ /**
+ * @file
+ * @brief  C++ wrapper class with  multiple loggers all sharing the same sink
+ * aka categories
+ *****************************************************************************/
+
+//-----------------------------------------------------------------------------
+// includes
+//-----------------------------------------------------------------------------
+
+// clang-format off
+#include <cppsl/log/logManager.hpp>
+
+#include <iostream>
+#include <filesystem>
+
+#include <spdlog/common.h>
+#include <spdlog/sinks/sink.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/sinks/syslog_sink.h>
+
+#include <cppsl/log/details/fallback_sink.hpp>
+#include <cppsl/log/details/rsyslog_sink.hpp>
+#include <fmt/format.h>
+// clang-format on
+
+namespace cppsl::log {
+
+static const char* LOG_MANAGER_INITIALIZATION_FAILED = "Logging manager initialization failed";
+
+/*************************************************************************/ /**
+ * open logger with all added sinks
+ * @param level default logging level if not set in sink
+ * @return true if successfully, otherwise - false
+ *****************************************************************************/
+bool LogManager::openLogger(spdlog::level::level_enum level) {
+  try {
+    if (!m_logSp)
+      throw spdlog::spdlog_ex("no logging manager instance created");
+
+    m_logSp->set_level(level);
+
+    // or you can even set multi_sink logger as default logger
+    if (m_logSp->sinks().empty()) {
+      if (!add_console_sink(OutputLog::err, Colored::color, level)) {
+        throw spdlog::spdlog_ex("cannot add console sink");
+      }
+    }
+    // register logger
+    spdlog::register_logger(m_logSp);
+    return true;
+
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cout << "Logging manager open failed: " << ex.what() << std::endl;
+    return false;
+  } catch (...) {
+    std::cout << "Logging manager open unexpected failed" << std::endl;
+    return false;
+  }
+}
+
+/**
+ * @brief Closes the logger by removing all sinks and dropping the logger.
+ *
+ * This method removes all sinks added to the logger and drops the logger. The logger can no longer be used after this method is called.
+ *
+ * @see removeSinks()
+ * @see spdlog::drop()
+ */
+void LogManager::closeLogger() {
+  removeSinks();
+  spdlog::drop(m_name);
+}
+
+/**
+ * Removes all sinks from the logger.
+ *
+ * This method clears all the sinks from the logger.
+ * After calling this method, there will be no sinks connected to the logger, and all log messages will be discarded.
+ */
+void LogManager::removeSinks() {
+  m_logSp->sinks().clear();
+}
+
+/**
+ * Adds a basic file sink to the logger.
+ *
+ * This method adds a basic file sink to the logger. A basic file sink is used to
+ * redirect log messages to a file.
+ *
+ * @param filename The name of the file to which the log messages should be written.
+ * @param truncate Determines whether the file should be truncated if it already exists.
+ * @param level The default logging level if not set in the sink.
+ * @return True if the basic file sink was added successfully, false otherwise.
+ *
+ * @exception spdlog::spdlog_ex Thrown when the creation of the basic file sink fails.
+ * @exception std::runtime_error Thrown when checking or creating the path for the file fails.
+ */
+bool LogManager::add_basic_file_sink(const std::string& filename, Truncate truncate,
+                                     spdlog::level::level_enum level) noexcept {
+  try {
+    // create path
+    if (!check_create_path(filename)) {
+      throw std::runtime_error(fmt::format("cannot check or create path for: {}", filename));
+    }
+    auto sinkPtr = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename, truncate == Truncate::by_open);
+    push_sink_safe(sinkPtr, level);
+    return true;
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << ex.what() << std::endl;
+    return false;
+  } catch (const std::runtime_error& ex) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << ex.what() << std::endl;
+    return false;
+  } catch (...) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << std::endl;
+    return false;
+  }
+}
+
+/**
+ * Adds a rotating file sink to the logger.
+ *
+ * This method adds a rotating file sink to the logger. A rotating file sink is used to
+ * redirect log messages to a file that rotates when it reaches a maximum file size.
+ *
+ * @param filename The name of the file to log to.
+ * @param max_file_size The maximum size of the log file before it rotates.
+ * @param max_files The maximum number of rotated log files to keep.
+ * @param level The default logging level if not set in the sink.
+ * @return True if the rotating file sink was added successfully, false otherwise.
+ *
+ * @exception std::runtime_error Thrown when the path for the log file cannot be checked or created.
+ * @exception spdlog::spdlog_ex Thrown when the creation of the rotating file sink fails.
+ */
+bool LogManager::add_rotation_file_sink(const std::string& filename, size_t max_file_size, size_t max_files,
+                                        spdlog::level::level_enum level) noexcept {
+  try {
+    if (!check_create_path(filename)) {
+      throw std::runtime_error(fmt::format("cannot check or create path for: {}", filename));
+    }
+    push_sink_safe(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(filename, max_file_size, max_files), level);
+    return true;
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << ex.what() << std::endl;
+    return false;
+  }
+}
+
+/**
+ * Adds a daily file sink to the logger.
+ *
+ * This method adds a sink that writes log messages to a daily log file. The log file is rotated
+ * daily at the specified hour and minute.
+ *
+ * @param filename The name of the log file.
+ * @param hour The hour at which rotation occurs (0-23).
+ * @param minute The minute at which rotation occurs (0-59).
+ * @param level The default logging level if not set in the sink.
+ * @return true if the daily file sink was added successfully, false otherwise.
+ *
+ * @exception std::runtime_error Thrown when checking or creating the path for the log file fails.
+ * @exception spdlog::spdlog_ex Thrown when the creation of the daily file sink fails.
+ */
+bool LogManager::add_daily_file_sink(const std::string& filename, int hour, int minute,
+                                     spdlog::level::level_enum level) noexcept {
+  try {
+    // create path
+    if (!check_create_path(filename)) {
+      throw std::runtime_error(fmt::format("cannot check or create path for: {}", filename));
+    }
+    push_sink_safe(std::make_shared<spdlog::sinks::daily_file_sink_mt>(filename, hour, minute), level);
+    return true;
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << ex.what() << std::endl;
+    return false;
+  }
+}
+
+/*************************************************************************/ /**
+ * @brief Add a console sink to the logger.
+ *
+ * This method adds a console sink to the logger. A console sink is used to
+ * redirect log messages to the console.
+ *
+ * @param to_stderr Determines whether the log messages should be redirected to stderr.
+ * @param colored Determines whether the log messages should be displayed in color.
+ * @param level The default logging level if not set in the sink.
+ * @return True if the console sink was added successfully, false otherwise.
+ *
+ * @exception spdlog::spdlog_ex Thrown when the creation of the console sink fails.
+ *****************************************************************************/
+bool LogManager::add_console_sink(OutputLog to_stderr, Colored colored, spdlog::level::level_enum level) noexcept {
+  if (!initialize_console_sink(to_stderr, colored, level)) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << std::endl;
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Initializes a console sink for logging.
+ *
+ * @param level The default logging level if not set in the sink.
+ * @return True if the console sink was successfully initialized, otherwise returns false.
+ */
+bool LogManager::initialize_console_sink(OutputLog output, Colored colored_output, spdlog::level::level_enum level) {
+  try {
+    auto sinkPtr = create_console_sink(output, colored_output);
+    push_sink_safe(sinkPtr, level);
+    return true;
+  } catch (const spdlog::spdlog_ex& e) {
+    std::cerr << e.what() << std::endl;
+    return false;
+  }
+}
+
+/**
+ * Creates a console sink for logging.
+ *
+ * @param level the logging level for the console sink
+ *
+ * @return true if the console sink is successfully created, false otherwise
+ */
+std::shared_ptr<spdlog::sinks::sink> LogManager::create_console_sink(OutputLog output,
+                                                                     Colored colored_output) noexcept {
+  if (colored_output == Colored::color) {
+    if (output == OutputLog::err) {
+      return std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+    } else {
+      return std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    }
+  } else {
+    if (output == OutputLog::err) {
+      return std::make_shared<spdlog::sinks::stderr_sink_mt>();
+    } else {
+      return std::make_shared<spdlog::sinks::stdout_sink_mt>();
+    }
+  }
+}
+
+/**
+ * Add syslog sink to the logger
+ * @param level default logging level if not set in syslog sink
+ * @return true if syslog sink is successfully added, otherwise - false
+ */
+bool LogManager::add_syslog_sink(const std::string& syslog_ident, int syslog_option, int syslog_facility,
+                                 bool enable_formatting, log_level level) noexcept {
+  try {
+    auto sinkPtr = std::make_shared<spdlog::sinks::syslog_sink_mt>(syslog_ident, syslog_option, syslog_facility,
+                                                                   enable_formatting);
+    sinkPtr->set_level(level);
+    push_sink_safe(sinkPtr, level);
+    return true;
+
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << ex.what() << std::endl;
+    return false;
+  } catch (...) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << std::endl;
+    return false;
+  }
+}
+
+/**
+ * Adds a new rsyslog sink to the logger
+ * @param address The address of the rsyslog server
+ * @param port The port number of the rsyslog server
+ * @return true if the rsyslog sink was added successfully, false otherwise
+ *****************************************************************************/
+bool LogManager::add_rsyslog_sink(const std::string& ident, const std::string& rsyslog_ip, int syslog_facility,
+                                  spdlog::level::level_enum lev, int port, bool enable_formatting,
+                                  int log_buffer_max_size) noexcept {
+  try {
+    auto sinkPtr = std::make_shared<spdlog::sinks::rsyslog_sink_mt>(ident, rsyslog_ip, syslog_facility,
+                                                                    log_buffer_max_size, port, enable_formatting);
+    sinkPtr->set_pattern("[%Y-%m-%d %H:%M:%S:%e] [%n] [%l] [%P] %@ : %v");
+    push_sink_safe(sinkPtr, lev);
+    return true;
+  } catch (const spdlog::spdlog_ex& ex) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << ex.what() << std::endl;
+    return false;
+  } catch (...) {
+    std::cerr << LOG_MANAGER_INITIALIZATION_FAILED << ": " << std::endl;
+    return false;
+  }
+}
+
+/**
+ * Checks if the specified path exists and creates it if it doesn't.
+ *
+ * @param path The path to check and create.
+ * @return <code>true</code> if the path exists or is successfully created, <code>false</code> otherwise.
+ */
+bool LogManager::check_create_path(const std::string& filename) {
+  // check parent folder
+  auto folder = std::filesystem::path(filename).parent_path();
+  if (folder.empty())
+    folder.assign("./");
+  else if (!std::filesystem::exists(folder)) {
+    // check  create directory
+    return std::filesystem::create_directories(folder);
+  }
+  return true;
+}
+
+/**
+ * Pushes a logging sink onto the logger's stack safely.
+ *
+ * @param sink The logging sink to push onto the stack.
+ *
+ * @remarks If the sink is successfully pushed onto the stack, it will be added to the list of active logging sinks.
+ * If the sink is not successfully pushed onto the stack, no changes will be made to the logger.
+ *
+ * @see pop_sink_safe
+ */
+void LogManager::push_sink_safe(std::shared_ptr<spdlog::sinks::sink> sinkPtr, spdlog::level::level_enum level) {
+  if (sinkPtr) {
+    sinkPtr->set_level(level);
+    if (!m_logSp) {
+      m_logSp = std::make_shared<spdlog::logger>(m_name, sinkPtr);
+    } else {
+      m_logSp->sinks().push_back(sinkPtr);
+    }
+  }
+}
+}  // namespace cppsl::log

--- a/subModules/CMakeLists.txt
+++ b/subModules/CMakeLists.txt
@@ -1,2 +1,5 @@
+# The inclusion of fmt and spdlog libraries is necessary for the new logging
+# features and rsyslog_sink implementation.
+
 add_subdirectory(fmt)
 add_subdirectory(spdlog)

--- a/subModules/CMakeLists.txt
+++ b/subModules/CMakeLists.txt
@@ -1,3 +1,2 @@
-#add_subdirectory(fmt)
-#add_subdirectory(spdlog)
-add_subdirectory(cppsl)
+add_subdirectory(fmt)
+add_subdirectory(spdlog)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(Catch2 REQUIRED)
+
+# enable testing
+enable_testing()
+
+# Add the test sources
+file(GLOB SOURCE_FILES *.cpp)
+
+# For each source file a test target is created
+foreach (SOURCE_PATH ${SOURCE_FILES})
+
+  get_filename_component(TargetName ${SOURCE_PATH} NAME_WE)
+
+  # Add test target
+  add_executable(${TargetName} ${SOURCE_PATH})
+
+  # add compiler definition
+  target_include_directories(${TargetName} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../lib/include)
+  target_include_directories(${TargetName} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+  ## link with library
+  #  target_link_libraries(${TargetName} gtest gtest_main)
+  target_link_libraries(${TargetName} PRIVATE Catch2::Catch2 cppsl)
+
+  # Add the test to CTest
+  add_test(NAME ${TargetName} COMMAND ${TargetName})
+
+endforeach ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,15 @@ find_package(Catch2 REQUIRED)
 enable_testing()
 
 # Add the test sources
-file(GLOB SOURCE_FILES *.cpp)
+# Add the test sources explicitly
+set(SOURCE_FILES
+   circularBufferTest.cpp
+   dequeSafeTest.cpp
+   logManagerTest.cpp
+   queueLockFreeTest.cpp
+   roundWatchTest.cpp
+)
+
 
 # For each source file a test target is created
 foreach (SOURCE_PATH ${SOURCE_FILES})

--- a/test/circularBufferTest.cpp
+++ b/test/circularBufferTest.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "cppsl/buffer/circularBuffer.hpp"
 

--- a/test/circularBufferTest.cpp
+++ b/test/circularBufferTest.cpp
@@ -1,6 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch_all.hpp>
-
+#include "catch.hpp"
 #include "cppsl/buffer/circularBuffer.hpp"
 
 using namespace cppsl::buffer;

--- a/test/circularBufferTest.cpp
+++ b/test/circularBufferTest.cpp
@@ -1,0 +1,69 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "cppsl/buffer/circularBuffer.hpp"
+
+using namespace cppsl::buffer;
+
+TEST_CASE("CircularBuffer operations", "[CircularBuffer]") {
+  CircularBuffer<int> buffer(8);
+
+  SECTION("Initial state") {
+    REQUIRE(buffer.empty());
+    REQUIRE(buffer.size() == 0);
+    REQUIRE(buffer.capacity() == 8);
+  }
+
+  SECTION("Push and pop operations") {
+    REQUIRE(buffer.push(1));
+    REQUIRE(buffer.push(2));
+    REQUIRE(buffer.push(3));
+    REQUIRE(buffer.size() == 3);
+    REQUIRE_FALSE(buffer.empty());
+
+    int value;
+    REQUIRE(buffer.pop(value));
+    REQUIRE(value == 1);
+    REQUIRE(buffer.pop(value));
+    REQUIRE(value == 2);
+    REQUIRE(buffer.pop(value));
+    REQUIRE(value == 3);
+    REQUIRE(buffer.empty());
+  }
+
+  SECTION("Buffer full and empty states") {
+    for (int i = 0; i < 8; ++i) {
+      if (i < 7)
+        REQUIRE(buffer.push(i));
+      else
+        REQUIRE_FALSE(buffer.push(i));
+    }
+    REQUIRE(buffer.full());
+    REQUIRE_FALSE(buffer.push(9));
+
+    int value;
+    for (int i = 0; i < 8; ++i) {
+      if (buffer.size()) {
+        REQUIRE(buffer.pop(value));
+        REQUIRE(value == i);
+      } else {
+        REQUIRE_FALSE(buffer.pop(value));
+      }
+    }
+    REQUIRE(buffer.empty());
+  }
+
+  SECTION("Clear buffer") {
+    REQUIRE(buffer.push(1));
+    REQUIRE(buffer.push(2));
+    REQUIRE(buffer.push(3));
+    REQUIRE(buffer.push(4));
+    REQUIRE(buffer.push(5));
+    REQUIRE(buffer.push(6));
+    REQUIRE(buffer.push(7));
+    REQUIRE(buffer.push(8) == false);
+    buffer.clear();
+    REQUIRE(buffer.empty());
+    REQUIRE(buffer.size() == 0);
+  }
+}

--- a/test/dequeSafeTest.cpp
+++ b/test/dequeSafeTest.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
+
 #include "cppsl/container/dequeSafe.hpp"
 
 TEST_CASE("DequeSafe operations", "[DequeSafe]") {

--- a/test/dequeSafeTest.cpp
+++ b/test/dequeSafeTest.cpp
@@ -1,0 +1,53 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "cppsl/container/dequeSafe.hpp"
+
+TEST_CASE("DequeSafe operations", "[DequeSafe]") {
+  cppsl::container::DequeSafe<int> deque;
+
+  SECTION("Initial state") {
+    REQUIRE(deque.empty());
+    REQUIRE(deque.size() == 0);
+  }
+
+  SECTION("Push and pop operations") {
+    deque.push_back(1);
+    deque.push_front(2);
+
+    REQUIRE(deque.size() == 2);
+    REQUIRE(deque.front() == 2);
+    REQUIRE(deque.back() == 1);
+
+    int value;
+    deque.wait_and_pop_front(value);
+    REQUIRE(value == 2);
+    REQUIRE(deque.size() == 1);
+
+    deque.wait_and_pop_back(value);
+    REQUIRE(value == 1);
+    REQUIRE(deque.empty());
+  }
+
+  SECTION("Try pop operations") {
+    deque.push_back(3);
+    deque.push_front(4);
+
+    int value;
+    REQUIRE(deque.try_pop_front(value));
+    REQUIRE(value == 4);
+    REQUIRE(deque.size() == 1);
+
+    REQUIRE(deque.try_pop_back(value));
+    REQUIRE(value == 3);
+    REQUIRE(deque.empty());
+  }
+
+  SECTION("Clear operation") {
+    deque.push_back(5);
+    deque.push_front(6);
+    deque.clear();
+
+    REQUIRE(deque.empty());
+    REQUIRE(deque.size() == 0);
+  }
+}

--- a/test/dequeSafeTest.cpp
+++ b/test/dequeSafeTest.cpp
@@ -1,6 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch_all.hpp>
-
+#include "catch.hpp"
 #include "cppsl/container/dequeSafe.hpp"
 
 TEST_CASE("DequeSafe operations", "[DequeSafe]") {
@@ -50,5 +49,31 @@ TEST_CASE("DequeSafe operations", "[DequeSafe]") {
 
     REQUIRE(deque.empty());
     REQUIRE(deque.size() == 0);
+  }
+
+  SECTION("Thread safety") {
+    std::vector<std::thread> threads;
+    const int iterations = 1000;
+    std::atomic<int> sum{0};
+
+    // Producer thread
+    threads.emplace_back([&]() {
+      for (int i = 0; i < iterations; ++i) {
+        deque.push_back(i);
+      }
+    });
+
+    // Consumer thread
+    threads.emplace_back([&]() {
+      int value;
+      for (int i = 0; i < iterations; ++i) {
+        deque.wait_and_pop_front(value);
+        sum += value;
+      }
+    });
+
+    for (auto& t : threads)
+      t.join();
+    REQUIRE(deque.empty());
   }
 }

--- a/test/logManagerTest.cpp
+++ b/test/logManagerTest.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
+
 #include "cppsl/log/logManager.hpp"
 
 TEST_CASE("LogManager operations", "[LogManager]") {

--- a/test/logManagerTest.cpp
+++ b/test/logManagerTest.cpp
@@ -2,38 +2,111 @@
 #include "catch.hpp"
 #include "cppsl/log/logManager.hpp"
 
-TEST_CASE("LogManager operations", "[LogManager]") {
-  cppsl::log::LogManager logManager("test_logger");
+TEST_CASE("LogManager default constructor", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.name() == "logman");
+  REQUIRE(logManager.number_sinks() == 0);
+  REQUIRE(logManager.empty() == true);
+}
 
-  SECTION("Initial state") {
-    REQUIRE(logManager.name() == "test_logger");
-    REQUIRE(logManager.empty());
-    REQUIRE(logManager.number_sinks() == 0);
-  }
+TEST_CASE("LogManager parameterized constructor", "[LogManager]") {
+  cppsl::log::LogManager logManager("testLogger");
+  REQUIRE(logManager.name() == "testLogger");
+  REQUIRE(logManager.number_sinks() == 0);
+  REQUIRE(logManager.empty() == true);
+}
 
-  SECTION("Add and remove sinks") {
-    REQUIRE(logManager.add_console_sink(cppsl::log::LogManager::OutputLog::out, cppsl::log::LogManager::Colored::color, spdlog::level::info));
-    REQUIRE_FALSE(logManager.empty());
-    REQUIRE(logManager.number_sinks() == 1);
+TEST_CASE("LogManager add_basic_file_sink", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.add_basic_file_sink("test.log", cppsl::log::LogManager::Truncate::by_open, spdlog::level::info) ==
+          true);
+  REQUIRE(logManager.number_sinks() == 1);
+}
 
-    logManager.removeSinks();
-    REQUIRE(logManager.empty());
-    REQUIRE(logManager.number_sinks() == 0);
-  }
+TEST_CASE("LogManager add_rotation_file_sink", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.add_rotation_file_sink("test.log", 1048576, 3, spdlog::level::info) == true);
+  REQUIRE(logManager.number_sinks() == 1);
+}
 
-  SECTION("Logging levels") {
-    logManager.set_level(spdlog::level::debug);
-    REQUIRE(logManager.level() == spdlog::level::debug);
+TEST_CASE("LogManager add_daily_file_sink", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.add_daily_file_sink("test.log", 0, 0, spdlog::level::info) == true);
+  REQUIRE(logManager.number_sinks() == 1);
+}
 
-    logManager.set_level(spdlog::level::info);
-    REQUIRE(logManager.level() == spdlog::level::info);
-  }
+TEST_CASE("LogManager add_console_sink", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.add_console_sink(cppsl::log::LogManager::OutputLog::out, cppsl::log::LogManager::Colored::color,
+                                      spdlog::level::info) == true);
+  REQUIRE(logManager.number_sinks() == 1);
+}
 
-  SECTION("Logger operations") {
-    REQUIRE(logManager.openLogger(spdlog::level::info));
-    logManager.info("This is an info message");
-    logManager.debug("This is a debug message");
-    logManager.error("This is an error message");
-    logManager.closeLogger();
-  }
+TEST_CASE("LogManager add_rsyslog_sink", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.add_rsyslog_sink("testIdent", "127.0.0.1", 1, spdlog::level::info) == true);
+  REQUIRE(logManager.number_sinks() == 1);
+}
+
+TEST_CASE("LogManager add_syslog_sink", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.add_syslog_sink("testIdent", 0, 1, true, spdlog::level::info) == true);
+  REQUIRE(logManager.number_sinks() == 1);
+}
+
+TEST_CASE("LogManager openLogger and closeLogger", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  REQUIRE(logManager.openLogger(spdlog::level::info) == true);
+  logManager.closeLogger();
+  REQUIRE(logManager.number_sinks() == 0);
+}
+
+TEST_CASE("LogManager set_level and level", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  logManager.set_level(spdlog::level::debug);
+  REQUIRE(logManager.level() == spdlog::level::debug);
+}
+
+TEST_CASE("LogManager false open empty log", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  logManager.set_level(spdlog::level::debug);
+  REQUIRE_FALSE(logManager.openLogger(spdlog::level::debug));
+}
+
+TEST_CASE("LogManager trace", "[LogManager]") {
+  cppsl::log::LogManager logManager{"testLogger"};
+  REQUIRE(logManager.add_console_sink(cppsl::log::LogManager::OutputLog::out, cppsl::log::LogManager::Colored::color,
+                                      spdlog::level::trace) == true);
+  REQUIRE(logManager.openLogger(spdlog::level::trace) == true);
+  REQUIRE_NOTHROW(logManager.trace("Trace message"));
+}
+
+TEST_CASE("LogManager debug", "[LogManager]") {
+  cppsl::log::LogManager logManager{"testLogger"};
+  logManager.openLogger(spdlog::level::debug);
+  REQUIRE_NOTHROW(logManager.debug("Debug message"));
+}
+
+TEST_CASE("LogManager info", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  logManager.openLogger(spdlog::level::info);
+  REQUIRE_NOTHROW(logManager.info("Info message"));
+}
+
+TEST_CASE("LogManager warn", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  logManager.openLogger(spdlog::level::warn);
+  REQUIRE_NOTHROW(logManager.warn("Warn message"));
+}
+
+TEST_CASE("LogManager error", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  logManager.openLogger(spdlog::level::err);
+  REQUIRE_NOTHROW(logManager.error("Error message"));
+}
+
+TEST_CASE("LogManager critical", "[LogManager]") {
+  cppsl::log::LogManager logManager;
+  auto ret = logManager.openLogger(spdlog::level::critical);
+  REQUIRE_NOTHROW(logManager.critical("Critical message"));
 }

--- a/test/logManagerTest.cpp
+++ b/test/logManagerTest.cpp
@@ -1,0 +1,39 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "cppsl/log/logManager.hpp"
+
+TEST_CASE("LogManager operations", "[LogManager]") {
+  cppsl::log::LogManager logManager("test_logger");
+
+  SECTION("Initial state") {
+    REQUIRE(logManager.name() == "test_logger");
+    REQUIRE(logManager.empty());
+    REQUIRE(logManager.number_sinks() == 0);
+  }
+
+  SECTION("Add and remove sinks") {
+    REQUIRE(logManager.add_console_sink(cppsl::log::LogManager::OutputLog::out, cppsl::log::LogManager::Colored::color, spdlog::level::info));
+    REQUIRE_FALSE(logManager.empty());
+    REQUIRE(logManager.number_sinks() == 1);
+
+    logManager.removeSinks();
+    REQUIRE(logManager.empty());
+    REQUIRE(logManager.number_sinks() == 0);
+  }
+
+  SECTION("Logging levels") {
+    logManager.set_level(spdlog::level::debug);
+    REQUIRE(logManager.level() == spdlog::level::debug);
+
+    logManager.set_level(spdlog::level::info);
+    REQUIRE(logManager.level() == spdlog::level::info);
+  }
+
+  SECTION("Logger operations") {
+    REQUIRE(logManager.openLogger(spdlog::level::info));
+    logManager.info("This is an info message");
+    logManager.debug("This is a debug message");
+    logManager.error("This is an error message");
+    logManager.closeLogger();
+  }
+}

--- a/test/logManagerTest.cpp
+++ b/test/logManagerTest.cpp
@@ -1,6 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch_all.hpp>
-
+#include "catch.hpp"
 #include "cppsl/log/logManager.hpp"
 
 TEST_CASE("LogManager operations", "[LogManager]") {

--- a/test/queueLockFreeTest.cpp
+++ b/test/queueLockFreeTest.cpp
@@ -1,0 +1,42 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "cppsl/container/queueLockFree.hpp"
+
+TEST_CASE("queueLockFree operations", "[queueLockFree]") {
+  cppsl::container::queueLockFree<int> queue;
+
+  SECTION("Initial state") {
+    REQUIRE(queue.empty());
+    REQUIRE(queue.front() == nullptr);
+    REQUIRE(queue.back() == nullptr);
+  }
+
+  SECTION("Push and pop operations") {
+    queue.push(1);
+    queue.push(2);
+
+    REQUIRE_FALSE(queue.empty());
+    REQUIRE(queue.front() != nullptr);
+    REQUIRE(queue.back() != nullptr);
+
+    auto front = queue.try_pop();
+    REQUIRE(front != nullptr);
+    REQUIRE(*front == 1);
+
+    front = queue.try_pop();
+    REQUIRE(front != nullptr);
+    REQUIRE(*front == 2);
+
+    REQUIRE(queue.empty());
+  }
+
+  SECTION("Try pop on empty queue") {
+    auto front = queue.try_pop();
+    REQUIRE(front == nullptr);
+  }
+
+  SECTION("Pop on empty queue") {
+    auto front = queue.pop();
+    REQUIRE(front == nullptr);
+  }
+}

--- a/test/queueLockFreeTest.cpp
+++ b/test/queueLockFreeTest.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include "cppsl/container/queueLockFree.hpp"
 
 TEST_CASE("queueLockFree operations", "[queueLockFree]") {

--- a/test/queueLockFreeTest.cpp
+++ b/test/queueLockFreeTest.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch_all.hpp>
+#include "catch.hpp"
 #include "cppsl/container/queueLockFree.hpp"
 
 TEST_CASE("queueLockFree operations", "[queueLockFree]") {

--- a/test/roundWatchTest.cpp
+++ b/test/roundWatchTest.cpp
@@ -1,6 +1,8 @@
 #define CATCH_CONFIG_MAIN
 #include <thread>
-#include <catch2/catch.hpp>
+
+#include <catch2/catch_all.hpp>
+
 #include "cppsl/time/roundWatch.hpp"
 
 using namespace cppsl::time;

--- a/test/roundWatchTest.cpp
+++ b/test/roundWatchTest.cpp
@@ -1,8 +1,7 @@
 #define CATCH_CONFIG_MAIN
 #include <thread>
 
-#include <catch2/catch_all.hpp>
-
+#include "catch.hpp"
 #include "cppsl/time/roundWatch.hpp"
 
 using namespace cppsl::time;

--- a/test/roundWatchTest.cpp
+++ b/test/roundWatchTest.cpp
@@ -1,0 +1,42 @@
+#define CATCH_CONFIG_MAIN
+#include <thread>
+#include <catch2/catch.hpp>
+#include "cppsl/time/roundWatch.hpp"
+
+using namespace cppsl::time;
+
+TEST_CASE("RoundWatch stores lap durations correctly", "[RoundWatch]") {
+  RoundWatch<> watch;
+
+  SECTION("Initial state") {
+    REQUIRE(watch.Laps().empty());
+  }
+
+  SECTION("StoreLap stores the first lap duration") {
+    watch.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    watch.StoreLap();
+    REQUIRE(watch.Laps().size() == 1);
+    REQUIRE(watch.Laps().front().total_time.count() >= 100);
+  }
+
+  SECTION("StoreLap stores multiple lap durations") {
+    watch.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    watch.StoreLap();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    watch.StoreLap();
+    REQUIRE(watch.Laps().size() == 2);
+    REQUIRE(watch.Laps()[0].total_time.count() >= 100);
+    REQUIRE(watch.Laps()[1].total_time.count() >= 300);
+    REQUIRE(watch.Laps()[1].split_time.count() >= 200);
+  }
+
+  SECTION("Reset clears all lap durations") {
+    watch.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    watch.StoreLap();
+    watch.Reset();
+    REQUIRE(watch.Laps().empty());
+  }
+}


### PR DESCRIPTION
Implemented unit tests for deque, logging, round watch, and circular buffer functionalities. Introduced a new `RoundWatch` utility in the time module and added `rsyslog_sink` for remote logging. Enabled building of test applications in CMake.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a thread-safe `CircularBuffer` and `DequeSafe` class for efficient data handling.
	- Added a lock-free `queueLockFree` class for concurrent queue operations.
	- Implemented a `RoundWatch` class for lap timing functionality.
	- Added a `LogManager` class for managing multiple logging sinks.
	- Introduced a custom logging sink for `spdlog` that supports fallback mechanisms and a remote syslog sink.
	- Enhanced CMake configuration for improved build management and testing setup.

- **Bug Fixes**
	- Enhanced error handling in logging operations and thread management.

- **Tests**
	- Comprehensive unit tests for `CircularBuffer`, `DequeSafe`, `LogManager`, `queueLockFree`, and `RoundWatch` classes to ensure functionality and reliability.

- **Documentation**
	- Updated documentation for new classes and methods to assist users in understanding the new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->